### PR TITLE
fix(updating): use PUT not PATCH when updating an existing Secret

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -98,7 +98,7 @@ class Poller {
     }
 
     this._logger.info(`updating secret ${secretName}`);
-    return kubeNamespace.secrets(secretName).patch({ body: secretManifest });
+    return kubeNamespace.secrets(secretName).put({ body: secretManifest });
   }
 
   /**

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -186,13 +186,13 @@ describe('Poller', () => {
 
     it('updates secret', async () => {
       kubeNamespaceMock.get = sinon.stub().resolves({ fakeSecretName: 'fakeSecretString' });
-      kubeNamespaceMock.patch = sinon.stub().resolves();
+      kubeNamespaceMock.put = sinon.stub().resolves();
 
       await poller._upsertKubernetesSecret(upsertSecretParams);
 
       expect(kubeNamespaceMock.secrets.calledWith('fakeSecretName')).to.be.true;
       expect(kubeNamespaceMock.get.called).to.be.true;
-      expect(kubeNamespaceMock.patch.calledWith({
+      expect(kubeNamespaceMock.put.calledWith({
         body: {
           apiVersion: 'v1',
           kind: 'Secret',


### PR DESCRIPTION
PATCH is going to result in a merge, potentially resulting in a union of the
previous Secret's fields and the updated Secret's fields.