### PR TITLE
fix(config): remove default aws region

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -16,14 +16,12 @@ if (environment === 'development') {
   require('dotenv').config()
 }
 
-const awsRegion = process.env.AWS_REGION || 'us-west-2'
 const eventsIntervalMilliseconds = process.env.EVENTS_INTERVAL_MILLISECONDS
   ? Number(process.env.EVENTS_INTERVAL_MILLISECONDS) : 60000
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 module.exports = {
-  awsRegion,
   environment,
   eventsIntervalMilliseconds,
   pollerIntervalMilliseconds

--- a/config/index.js
+++ b/config/index.js
@@ -29,9 +29,9 @@ const customResourceManager = new CustomResourceManager({
   logger
 })
 
-const secretsManagerClient = new AWS.SecretsManager({ region: envConfig.awsRegion })
+const secretsManagerClient = new AWS.SecretsManager()
 const secretsManagerBackend = new SecretsManagerBackend({ client: secretsManagerClient, logger })
-const systemManagerClient = new AWS.SSM({ region: envConfig.awsRegion })
+const systemManagerClient = new AWS.SSM()
 const systemManagerBackend = new SystemManagerBackend({ client: systemManagerClient, logger })
 const backends = {
   secretsManager: secretsManagerBackend,


### PR DESCRIPTION
This address https://github.com/godaddy/kubernetes-external-secrets/issues/51

Removing "hardcoded" aws default region in favor of using default behavior of AWS SDK.