### PR TITLE
Fix and extend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,28 @@ data:
   password: MTIzNA==
 ```
 
+The controller needs to access AWS Secrets Manager via a role. How depends on your cluster setup, [kube2iam](https://github.com/jtblin/kube2iam) and [kiam](https://github.com/uswitch/kiam) are the most common
+
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetRandomPassword",
+                "secretsmanager:GetResourcePolicy",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:ListSecrets",
+                "secretsmanager:ListSecretVersionIds"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
 ## Backends
 
 kubernetes-external-secrets supports only AWS Secrets Manager.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: hello-service
+  namespace: default
 secretDescriptor:
   backendType: secretsManager
   data:
@@ -133,7 +134,7 @@ data:
   password: MTIzNA==
 ```
 
-The controller needs to access AWS Secrets Manager via a role. How depends on your cluster setup, [kube2iam](https://github.com/jtblin/kube2iam) and [kiam](https://github.com/uswitch/kiam) are the most common
+The controller needs to access AWS Secrets Manager via a role. How depends on your cluster setup, [kube2iam](https://github.com/jtblin/kube2iam) and [kiam](https://github.com/uswitch/kiam) are the most common IAM role plugins.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 
 | Parameter                            | Description                                                  | Default                                                 |
 | ------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------- |
-| `env.AWS_DEFAULT_REGION`             | Set AWS_DEFAULT_REGION in Deployment Pod                     | `us-west-2`                                             |
+| `env.AWS_REGION`             | Set AWS_REGION in Deployment Pod                     | `us-west-2`                                             |
 | `env.EVENTS_INTERVAL_MILLISECONDS`   | Set EVENTS_INTERVAL_MILLISECONDS in Deployment Pod           | `60000`                                                 |
 | `env.POLLER_INTERVAL_MILLISECONDS`   | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod           | `10000`                                                 |
 | `image.repository`                   | kubernetes-external-secrets Image name                       | `godaddy/kubernetes-external-secrets`                   |


### PR DESCRIPTION
A few improvements to the documentation, things that were unclear to me as and outsider of this project:
* You need to set AWS_REGION instead of AWS_DEFAULT_REGION, this is specified in the official docs as well: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-region.html 
* the controller needs either credentials or a role to read from AWS Secrets Manager, it's kinda obvious but I feel like this belongs in the doc anyway
* small nitpick since it's not mentioned anywhere but supported, adding namespace to the example as an implicit option
