### PR TITLE
fix(AWSSM): treat value as object iff the es specifies .property

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -28,8 +28,16 @@ class KVBackend extends AbstractBackend {
       const value = await this._get({ secretKey: secretProperty.key })
 
       if ('property' in secretProperty) {
-        return value[secretProperty.property]
+        let parsedValue
+        try {
+          parsedValue = JSON.parse(value)
+        } catch (err) {
+          this._logger.warn(`Failed to JSON.parse '${value}':`, err)
+          return undefined
+        }
+        return parsedValue[secretProperty.property]
       }
+
       return value
     }))
   }

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -33,7 +33,7 @@ class KVBackend extends AbstractBackend {
           parsedValue = JSON.parse(value)
         } catch (err) {
           this._logger.warn(`Failed to JSON.parse '${value}':`, err)
-          return undefined
+          return
         }
         return parsedValue[secretProperty.property]
       }

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -13,6 +13,7 @@ describe('SecretsManagerBackend', () => {
   beforeEach(() => {
     loggerMock = sinon.mock()
     loggerMock.info = sinon.stub()
+    loggerMock.warn = sinon.stub()
 
     kvBackend = new KVBackend({
       logger: loggerMock
@@ -26,7 +27,7 @@ describe('SecretsManagerBackend', () => {
     })
 
     it('handles secrets values that are objects', async () => {
-      kvBackend._get.onFirstCall().resolves({ foo: 'bar' })
+      kvBackend._get.onFirstCall().resolves('{"foo":"bar"}')
       const secretPropertyValues = await kvBackend._fetchSecretPropertyValues({
         externalData: [{
           key: 'mocked-key',
@@ -35,6 +36,18 @@ describe('SecretsManagerBackend', () => {
         }]
       })
       expect(secretPropertyValues).to.deep.equal(['bar'])
+    })
+
+    it('handles invalid JSON objects', async () => {
+      kvBackend._get.onFirstCall().resolves('{')
+      const secretPropertyValues = await kvBackend._fetchSecretPropertyValues({
+        externalData: [{
+          key: 'mocked-key',
+          name: 'mocked-name',
+          property: 'foo'
+        }]
+      })
+      expect(secretPropertyValues).to.deep.equal([undefined])
     })
 
     it('fetches secret property values', async () => {

--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -24,12 +24,7 @@ class SecretsManagerBackend extends KVBackend {
       .getSecretValue({ SecretId: secretKey })
       .promise()
 
-    const secretValue = data.SecretString
-    try {
-      return JSON.parse(secretValue)
-    } catch (err) {
-      return secretValue
-    }
+    return data.SecretString
   }
 }
 


### PR DESCRIPTION
See https://github.com/godaddy/kubernetes-external-secrets/issues/73 for
discussion.