### PR TITLE
Show error on missing property

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -35,6 +35,11 @@ class KVBackend extends AbstractBackend {
           this._logger.warn(`Failed to JSON.parse '${value}':`, err)
           return
         }
+
+        if (!(secretProperty.property in parsedValue)) {
+          throw new Error('Could not find property ' + secretProperty.property + ' in ' + secretProperty.key)
+        }
+
         return parsedValue[secretProperty.property]
       }
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -64,7 +64,8 @@ class Poller {
         return this._upsertKubernetesSecret({ secretDescriptor })
       }))
     } catch (err) {
-      this._logger.error('failure while polling the secrets', err)
+      this._logger.error('failure while polling the secrets')
+      this._logger.error(err.toString())
     }
   }
 


### PR DESCRIPTION
The polling function was not outputting an error message when a property is missing from a secret. This addresses #63 .