### PR TITLE
chore(kubectl): bring back the external-secrets.yml file

### DIFF
--- a/external-secrets.yml
+++ b/external-secrets.yml
@@ -1,0 +1,69 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets-cluster-role-binding
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-external-secrets-service-account
+  namespace: kubernetes-external-secrets
+roleRef:
+  kind: ClusterRole
+  name: kubernetes-external-secrets-cluster-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-external-secrets-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create", "update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  resourceNames: ["externalsecrets.kubernetes-client.io"]
+  verbs: ["get", "update"]
+- apiGroups: ["kubernetes-client.io"]
+  resources: ["externalsecrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-external-secrets
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-external-secrets-service-account
+  namespace: kubernetes-external-secrets
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    name: kubernetes-external-secrets
+  name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: kubernetes-external-secrets
+  template:
+    metadata:
+      labels:
+        name: kubernetes-external-secrets
+        service: kubernetes-external-secrets
+    spec:
+      serviceAccountName: kubernetes-external-secrets-service-account
+      containers:
+        - image: "godaddy/kubernetes-external-secrets:1.2.2"
+          imagePullPolicy: Always
+          name: kubernetes-external-secrets
+          env:
+            - name: AWS_REGION
+              value: us-west-2


### PR DESCRIPTION
This needs a few improvements to be ready for prime time. See discussion in:

https://github.com/godaddy/kubernetes-external-secrets/issues/89