### PR TITLE
Add ownerreference to remove created secret when external secret is removed

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -30,14 +30,15 @@ class Daemon {
     this._pollers = {}
   }
 
-  _createPoller ({ namespace, secretDescriptors }) {
+  _createPoller ({ namespace, secretDescriptors, ownerReference }) {
     return new Poller({
       backends: this._backends,
       intervalMilliseconds: this._pollerIntervalMilliseconds,
       kubeClient: this._kubeClient,
       logger: this._logger,
       namespace,
-      secretDescriptors
+      secretDescriptors,
+      ownerReference
     })
   }
 
@@ -52,7 +53,15 @@ class Daemon {
     // NOTE(jdaeli): hash this in case resource version becomes too long?
     const id = `${name}_${resourceVersion}`
     const secretDescriptors = [{ ...secretDescriptor, name }]
-    return { id, namespace, secretDescriptors }
+    const ownerReference = {
+      apiVersion: object.apiVersion,
+      controller: true,
+      kind: object.kind,
+      name: metadata.name,
+      uid: metadata.uid
+    }
+
+    return { id, namespace, secretDescriptors, ownerReference }
   }
 
   /**
@@ -82,7 +91,8 @@ class Daemon {
 
         const poller = this._createPoller({
           namespace: descriptor.namespace,
-          secretDescriptors: descriptor.secretDescriptors
+          secretDescriptors: descriptor.secretDescriptors,
+          ownerReference: descriptor.ownerReference
         })
 
         // handle duplicate ADDED events

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -23,14 +23,22 @@ class Poller {
    * @param {string} namespace - Kubernetes namespace.
    * @param {SecretDescriptor[]} secretDescriptors - Kubernetes secret descriptors.
    */
-  constructor ({ backends, intervalMilliseconds, kubeClient, logger, namespace, secretDescriptors }) {
+  constructor ({
+    backends,
+    intervalMilliseconds,
+    kubeClient,
+    logger,
+    namespace,
+    secretDescriptors,
+    ownerReference
+  }) {
     this._backends = backends
     this._intervalMilliseconds = intervalMilliseconds
     this._kubeClient = kubeClient
     this._logger = logger
     this._namespace = namespace
     this._secretDescriptors = secretDescriptors
-
+    this._ownerReference = ownerReference
     this._interval = null
   }
 
@@ -46,7 +54,10 @@ class Poller {
       apiVersion: 'v1',
       kind: 'Secret',
       metadata: {
-        name: secretDescriptor.name
+        name: secretDescriptor.name,
+        ownerReferences: [
+          this._ownerReference
+        ]
       },
       type: 'Opaque',
       data

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -12,6 +12,14 @@ describe('Poller', () => {
   let loggerMock
   let poller
 
+  const ownerReference = {
+    apiVersion: 'owner-api/v1',
+    controller: true,
+    kind: 'MyKind',
+    name: 'fakeSecretName',
+    uid: '4c10d879-2646-40dc-8595-d0b06b60a9ed'
+  }
+
   beforeEach(() => {
     backendMock = sinon.mock()
     kubeClientMock = sinon.mock()
@@ -27,7 +35,8 @@ describe('Poller', () => {
       intervalMilliseconds: 5000,
       kubeClient: kubeClientMock,
       logger: loggerMock,
-      namespace: 'fakeNamespace'
+      namespace: 'fakeNamespace',
+      ownerReference
     })
   })
 
@@ -72,7 +81,8 @@ describe('Poller', () => {
         apiVersion: 'v1',
         kind: 'Secret',
         metadata: {
-          name: 'fakeSecretName'
+          name: 'fakeSecretName',
+          ownerReferences: [ownerReference]
         },
         type: 'Opaque',
         data: {
@@ -154,7 +164,7 @@ describe('Poller', () => {
         secretDescriptor: {
           backendType: 'fakeBackendType',
           name: 'fakeSecretName',
-          properties: ['fakePropertyName1']
+          properties: ['fakePropertyName']
         }
       }
     })


### PR DESCRIPTION
Fixes #93

Not sure how you would like it configureable and what kind of defaults?

Figured I'd just draft a PR first 😄 

Im abit unsure about whether I plugged it in, in the right place. Seeing how `secretDescriptors` is an array being sent around, but its always just one?

I could add the ownerReference into the `secretDescriptor` object (https://github.com/godaddy/kubernetes-external-secrets/pull/95/files#diff-5c2754430010d5f3e95b45e1bb36d58bR55) but it feels weird to put it in there as well as its just some metadata and not part of the secretDescriptor 