### PR TITLE
fix: remove logging of potentially secret value

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -32,12 +32,14 @@ class KVBackend extends AbstractBackend {
         try {
           parsedValue = JSON.parse(value)
         } catch (err) {
-          this._logger.warn(`Failed to JSON.parse '${value}':`, err)
+          this._logger.warn(`Failed to JSON.parse value for '${secretProperty.key}',` +
+           ` please verify that your secret value is correctly formatted as JSON.` +
+           ` To use plain text secret remove the 'property: ${secretProperty.property}'`)
           return
         }
 
         if (!(secretProperty.property in parsedValue)) {
-          throw new Error(`Could not find property ${secretProperty.property} in secretProperty.key`)
+          throw new Error(`Could not find property ${secretProperty.property} in ${secretProperty.key}`)
         }
 
         return parsedValue[secretProperty.property]


### PR DESCRIPTION
If one misconfigures a secret these can end up in logs, which could be quite a hassle :)

Example:

```yaml
...
secretDescriptor:
  backendType: secretsManager
  data:
    - key: hello-service/credentials
      property: password
      name: password
```

hello-service/credentials from secrets manager:
```js
{
    "Name": "hello-service/credentials",
    "SecretString": "my-super-secret-password",
    ...
}
```

Would log the following 
```
Failed to JSON.parse 'my-super-secret-password': {}
```