### PR TITLE
refactor: poller.js and daemon.js

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -30,38 +30,25 @@ class Daemon {
     this._pollers = {}
   }
 
-  _createPoller ({ namespace, secretDescriptors, ownerReference }) {
-    return new Poller({
-      backends: this._backends,
-      intervalMilliseconds: this._pollerIntervalMilliseconds,
-      kubeClient: this._kubeClient,
-      logger: this._logger,
-      namespace,
-      secretDescriptors,
-      ownerReference
-    })
-  }
-
   /**
    * Create a poller descriptor from externalsecret resources.
    * @param {Object} object - externalsecret manifest.
    * @returns {Object} Poller descriptor.
    */
-  _createPollerDescriptor (object) {
-    const { metadata, secretDescriptor } = object
-    const { name, namespace, resourceVersion } = metadata
+  _createPollerDescriptor (externalSecret) {
+    const { name, namespace, resourceVersion } = externalSecret.metadata
     // NOTE(jdaeli): hash this in case resource version becomes too long?
     const id = `${name}_${resourceVersion}`
-    const secretDescriptors = [{ ...secretDescriptor, name }]
+    const secretDescriptor = { ...externalSecret.secretDescriptor, name }
     const ownerReference = {
-      apiVersion: object.apiVersion,
+      apiVersion: externalSecret.apiVersion,
       controller: true,
-      kind: object.kind,
-      name: metadata.name,
-      uid: metadata.uid
+      kind: externalSecret.kind,
+      name: externalSecret.metadata.name,
+      uid: externalSecret.metadata.uid
     }
 
-    return { id, namespace, secretDescriptors, ownerReference }
+    return { id, namespace, secretDescriptor, ownerReference }
   }
 
   /**
@@ -89,9 +76,13 @@ class Daemon {
         const descriptor = this._createPollerDescriptor(event.object)
         this._logger.info('spinning up poller', descriptor)
 
-        const poller = this._createPoller({
+        const poller = new Poller({
+          backends: this._backends,
+          intervalMilliseconds: this._pollerIntervalMilliseconds,
+          kubeClient: this._kubeClient,
+          logger: this._logger,
           namespace: descriptor.namespace,
-          secretDescriptors: descriptor.secretDescriptors,
+          secretDescriptor: descriptor.secretDescriptor,
           ownerReference: descriptor.ownerReference
         })
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -21,7 +21,7 @@ class Poller {
    * @param {Object} kubeClient - Client for interacting with kubernetes cluster.
    * @param {Object} logger - Logger for logging stuff.
    * @param {string} namespace - Kubernetes namespace.
-   * @param {SecretDescriptor[]} secretDescriptors - Kubernetes secret descriptors.
+   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret descriptor.
    */
   constructor ({
     backends,
@@ -29,7 +29,7 @@ class Poller {
     kubeClient,
     logger,
     namespace,
-    secretDescriptors,
+    secretDescriptor,
     ownerReference
   }) {
     this._backends = backends
@@ -37,7 +37,7 @@ class Poller {
     this._kubeClient = kubeClient
     this._logger = logger
     this._namespace = namespace
-    this._secretDescriptors = secretDescriptors
+    this._secretDescriptor = secretDescriptor
     this._ownerReference = ownerReference
     this._interval = null
   }
@@ -71,9 +71,7 @@ class Poller {
   async _poll () {
     this._logger.info('running poll')
     try {
-      await Promise.all(this._secretDescriptors.map(secretDescriptor => {
-        return this._upsertKubernetesSecret({ secretDescriptor })
-      }))
+      await this._upsertKubernetesSecret({ secretDescriptor: this._secretDescriptor })
     } catch (err) {
       this._logger.error('failure while polling the secrets')
       this._logger.error(err)

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -95,10 +95,11 @@ describe('Poller', () => {
 
   describe('_poll', () => {
     beforeEach(() => {
-      poller._secretDescriptors = [
-        { backendType: 'fakeBackendType', name: 'fakeSecretName1', properties: ['fakePropertyName1', 'fakePropertyName2'] },
-        { backendType: 'fakeBackendType', name: 'fakeSecretName2', properties: ['fakePropertyName3', 'fakePropertyName4'] }
-      ]
+      poller._secretDescriptor = {
+        backendType: 'fakeBackendType',
+        name: 'fakeSecretName1',
+        properties: ['fakePropertyName1', 'fakePropertyName2']
+      }
       poller._upsertKubernetesSecret = sinon.stub()
     })
 
@@ -115,16 +116,6 @@ describe('Poller', () => {
           properties: [
             'fakePropertyName1',
             'fakePropertyName2'
-          ]
-        }
-      })).to.equal(true)
-      expect(poller._upsertKubernetesSecret.calledWith({
-        secretDescriptor: {
-          backendType: 'fakeBackendType',
-          name: 'fakeSecretName2',
-          properties: [
-            'fakePropertyName3',
-            'fakePropertyName4'
           ]
         }
       })).to.equal(true)


### PR DESCRIPTION
Make it clear that there's a 1:1 mapping between a `Poller` and an
ExternalSecret.

Both files could use another refactor pass.