### PR TITLE
refactor: use watch api and instant poll new or modified secrets

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -15,7 +15,6 @@ const {
   kubeClient,
   customResourceManager,
   customResourceManifest,
-  eventsIntervalMilliseconds,
   logger,
   pollerIntervalMilliseconds
 } = require('../config')
@@ -31,7 +30,6 @@ async function main () {
   const externalSecretEvents = getExternalSecretEvents({
     kubeClient,
     customResourceManifest,
-    intervalMilliseconds: eventsIntervalMilliseconds,
     logger
   })
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,13 +16,10 @@ if (environment === 'development') {
   require('dotenv').config()
 }
 
-const eventsIntervalMilliseconds = process.env.EVENTS_INTERVAL_MILLISECONDS
-  ? Number(process.env.EVENTS_INTERVAL_MILLISECONDS) : 60000
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 module.exports = {
   environment,
-  eventsIntervalMilliseconds,
   pollerIntervalMilliseconds
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,7 +19,10 @@ if (environment === 'development') {
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
+const logLevel = process.env.LOG_LEVEL || 'info'
+
 module.exports = {
   environment,
-  pollerIntervalMilliseconds
+  pollerIntervalMilliseconds,
+  logLevel
 }

--- a/config/index.js
+++ b/config/index.js
@@ -20,7 +20,8 @@ const kubeClient = new kube.Client({ backend: kubeBackend })
 const logger = pino({
   serializers: {
     err: pino.stdSerializers.err
-  }
+  },
+  level: envConfig.logLevel
 })
 
 const customResourceManager = new CustomResourceManager({

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -66,7 +66,7 @@ class Daemon {
     Object.keys(this._pollers).forEach(pollerId => this._removePoller(pollerId))
   }
 
-  _addPoller (descriptor) {
+  _addPoller (descriptor, forcePoll = false) {
     this._logger.info('spinning up poller', descriptor)
 
     const poller = new Poller({
@@ -79,7 +79,7 @@ class Daemon {
       ownerReference: descriptor.ownerReference
     })
 
-    this._pollers[descriptor.id] = poller.start()
+    this._pollers[descriptor.id] = poller.start({ forcePoll })
   }
 
   /**
@@ -102,7 +102,7 @@ class Daemon {
 
         case 'MODIFIED': {
           this._removePoller(descriptor.id)
-          this._addPoller(descriptor)
+          this._addPoller(descriptor, true)
           break
         }
 

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -36,19 +36,18 @@ class Daemon {
    * @returns {Object} Poller descriptor.
    */
   _createPollerDescriptor (externalSecret) {
-    const { name, namespace, resourceVersion } = externalSecret.metadata
+    const { uid, name, namespace } = externalSecret.metadata
     // NOTE(jdaeli): hash this in case resource version becomes too long?
-    const id = `${name}_${resourceVersion}`
     const secretDescriptor = { ...externalSecret.secretDescriptor, name }
     const ownerReference = {
       apiVersion: externalSecret.apiVersion,
       controller: true,
       kind: externalSecret.kind,
-      name: externalSecret.metadata.name,
-      uid: externalSecret.metadata.uid
+      name,
+      uid
     }
 
-    return { id, namespace, secretDescriptor, ownerReference }
+    return { id: uid, namespace, secretDescriptor, ownerReference }
   }
 
   /**
@@ -56,13 +55,31 @@ class Daemon {
    * @param {String} pollerId - ID of the poller to remove.
    */
   _removePoller (pollerId) {
-    this._logger.info(`stopping and removing poller ${pollerId}`)
-    this._pollers[pollerId].stop()
-    delete this._pollers[pollerId]
+    if (this._pollers[pollerId]) {
+      this._logger.info(`stopping and removing poller ${pollerId}`)
+      this._pollers[pollerId].stop()
+      delete this._pollers[pollerId]
+    }
   }
 
   _removePollers () {
     Object.keys(this._pollers).forEach(pollerId => this._removePoller(pollerId))
+  }
+
+  _addPoller (descriptor) {
+    this._logger.info('spinning up poller', descriptor)
+
+    const poller = new Poller({
+      backends: this._backends,
+      intervalMilliseconds: this._pollerIntervalMilliseconds,
+      kubeClient: this._kubeClient,
+      logger: this._logger,
+      namespace: descriptor.namespace,
+      secretDescriptor: descriptor.secretDescriptor,
+      ownerReference: descriptor.ownerReference
+    })
+
+    this._pollers[descriptor.id] = poller.start()
   }
 
   /**
@@ -70,28 +87,34 @@ class Daemon {
    */
   async start () {
     for await (const event of this._externalSecretEvents) {
-      if (event.type === 'DELETED_ALL') {
-        this._removePollers()
-      } else if (event.type === 'ADDED') {
-        const descriptor = this._createPollerDescriptor(event.object)
-        this._logger.info('spinning up poller', descriptor)
+      const descriptor = event.object ? this._createPollerDescriptor(event.object) : null
 
-        const poller = new Poller({
-          backends: this._backends,
-          intervalMilliseconds: this._pollerIntervalMilliseconds,
-          kubeClient: this._kubeClient,
-          logger: this._logger,
-          namespace: descriptor.namespace,
-          secretDescriptor: descriptor.secretDescriptor,
-          ownerReference: descriptor.ownerReference
-        })
-
-        // handle duplicate ADDED events
-        if (this._pollers[descriptor.id]) {
+      switch (event.type) {
+        case 'DELETED': {
           this._removePoller(descriptor.id)
+          break
         }
 
-        this._pollers[descriptor.id] = poller.start()
+        case 'ADDED': {
+          this._addPoller(descriptor)
+          break
+        }
+
+        case 'MODIFIED': {
+          this._removePoller(descriptor.id)
+          this._addPoller(descriptor)
+          break
+        }
+
+        case 'DELETED_ALL': {
+          this._removePollers()
+          break
+        }
+
+        default: {
+          this._logger.warn(event, 'Unhandled event type %s', event.type)
+          break
+        }
       }
     }
   }

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -2,6 +2,12 @@
 
 const JSONStream = require('json-stream')
 
+/**
+ * Creates an FIFO queue which you can put to and take from.
+ * If theres nothing to take it will wait with resolving until
+ * something is put to the queue.
+ * @returns {Object} Queue instance with put and take methods
+ */
 function createEventQueue () {
   const queuedEvents = []
   const waitingResolvers = []

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -1,53 +1,88 @@
 'use strict'
 
-/**
- * Block asynchronous flow.
- * @param {number} milliseconds - Number of milliseconds to block flow operation.
- * @returns {Promise} Promise object representing block flow operation.
- */
-function sleep ({ milliseconds }) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
+const JSONStream = require('json-stream')
+
+function createEventQueue () {
+  const queuedEvents = []
+  const waitingResolvers = []
+
+  return {
+    take: () => queuedEvents.length > 0
+      ? Promise.resolve(queuedEvents.shift())
+      : new Promise(resolve => waitingResolvers.push(resolve)),
+    put: (msg) => waitingResolvers.length > 0
+      ? waitingResolvers.shift()(msg)
+      : queuedEvents.push(msg)
+  }
+}
+
+async function startWatcher ({
+  kubeClient,
+  customResourceManifest,
+  logger,
+  eventQueue
+}) {
+  const deathQueue = createEventQueue()
+
+  try {
+    while (true) {
+      logger.info('Starting watch stream')
+
+      const stream = kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.watch[customResourceManifest.spec.names.plural]
+        .getStream()
+
+      const jsonStream = new JSONStream()
+      stream.pipe(jsonStream)
+
+      jsonStream.on('data', eventQueue.put)
+
+      jsonStream.on('error', (err) => {
+        logger.warn(err, 'Got error on stream')
+        deathQueue.put('ERROR')
+      })
+
+      jsonStream.on('end', () => {
+        deathQueue.put('END')
+      })
+
+      await deathQueue.take()
+
+      logger.debug('Stopping watch stream')
+      eventQueue.put({ type: 'DELETED_ALL' })
+
+      stream.abort()
+    }
+  } catch (err) {
+    logger.error(err, 'Watcher crashed')
+  }
 }
 
 /**
  * Get a stream of external secret events. This implementation uses
- * polling/batching and converts it to a stream of events.
+ * watch and yields as a stream of events.
  * @param {Object} kubeClient - Client for interacting with kubernetes cluster.
  * @param {Object} customResourceManifest - Custom resource manifest.
- * @param {number} intervalMilliseconds - Interval time in milliseconds for polling external secrets.
- * @param {Object} logger - Logger for logging stuff.
  * @returns {Object} An async generator that yields externalsecret events.
  */
 function getExternalSecretEvents ({
   kubeClient,
   customResourceManifest,
-  intervalMilliseconds,
   logger
 }) {
   return (async function * () {
+    const eventQueue = createEventQueue()
+
+    startWatcher({
+      kubeClient,
+      customResourceManifest,
+      logger,
+      eventQueue
+    })
+
     while (true) {
-      try {
-        const externalSecrets = await kubeClient
-          .apis[customResourceManifest.spec.group]
-          .v1[customResourceManifest.spec.names.plural]
-          .get()
-
-        // this is analagous to handling a disconnect from a watch stream
-        yield {
-          type: 'DELETED_ALL'
-        }
-
-        // simulate a bunch of ADDED events
-        for (const externalSecret of externalSecrets.body.items) {
-          yield {
-            type: 'ADDED',
-            object: externalSecret
-          }
-        }
-      } catch (err) {
-        logger.warn('Failed to fetch external secrets', err)
-      }
-      await sleep({ milliseconds: intervalMilliseconds })
+      yield await eventQueue.take()
     }
   }())
 }

--- a/lib/external-secret.js
+++ b/lib/external-secret.js
@@ -32,7 +32,7 @@ async function startWatcher ({
 
   try {
     while (true) {
-      logger.info('Starting watch stream')
+      logger.debug('Starting watch stream')
 
       const stream = kubeClient
         .apis[customResourceManifest.spec.group]

--- a/lib/external-secret.test.js
+++ b/lib/external-secret.test.js
@@ -43,6 +43,7 @@ describe('getExternalSecretEvents', () => {
     loggerMock.info = sinon.stub()
     loggerMock.warn = sinon.stub()
     loggerMock.error = sinon.stub()
+    loggerMock.debug = sinon.stub()
   })
 
   it('gets a stream of external secret events', async () => {

--- a/lib/external-secret.test.js
+++ b/lib/external-secret.test.js
@@ -3,6 +3,7 @@
 
 const { expect } = require('chai')
 const sinon = require('sinon')
+const { Readable } = require('stream')
 
 const { getExternalSecretEvents } = require('./external-secret')
 
@@ -11,6 +12,7 @@ describe('getExternalSecretEvents', () => {
   let externalSecretsApiMock
   let fakeCustomResourceManifest
   let loggerMock
+  let mockedStream
 
   beforeEach(() => {
     fakeCustomResourceManifest = {
@@ -22,36 +24,77 @@ describe('getExternalSecretEvents', () => {
       }
     }
     externalSecretsApiMock = sinon.mock()
+
+    mockedStream = new Readable()
+    mockedStream._read = () => {}
+
     externalSecretsApiMock.get = sinon.stub()
     kubeClientMock = sinon.mock()
     kubeClientMock.apis = sinon.mock()
     kubeClientMock.apis['kubernetes-client.io'] = sinon.mock()
     kubeClientMock.apis['kubernetes-client.io'].v1 = sinon.mock()
+    kubeClientMock.apis['kubernetes-client.io'].v1.watch = sinon.mock()
     kubeClientMock.apis['kubernetes-client.io']
-      .v1.externalsecrets = externalSecretsApiMock
+      .v1.watch.externalsecrets = sinon.mock()
+    kubeClientMock.apis['kubernetes-client.io']
+      .v1.watch.externalsecrets.getStream = () => mockedStream
+
     loggerMock = sinon.mock()
+    loggerMock.info = sinon.stub()
+    loggerMock.warn = sinon.stub()
+    loggerMock.error = sinon.stub()
   })
 
   it('gets a stream of external secret events', async () => {
-    const fakeExternalSecretObject = { type: 'ExternalSecret' }
-    externalSecretsApiMock.get.resolves({
-      body: {
-        items: [fakeExternalSecretObject]
-      }
-    })
+    const fakeExternalSecretObject = {
+      apiVersion: 'kubernetes-client.io/v1',
+      kind: 'ExternalSecret',
+      metadata: {
+        name: 'my-secret',
+        namespace: 'default'
+      },
+      secretDescriptor: { backendType: 'secretsManager', data: [] }
+    }
 
     const events = getExternalSecretEvents({
       kubeClient: kubeClientMock,
       customResourceManifest: fakeCustomResourceManifest,
-      intervalMilliseconds: 0,
       logger: loggerMock
     })
 
-    const deletedAllEvent = await events.next()
-    expect(deletedAllEvent.value.type).is.equal('DELETED_ALL')
+    mockedStream.push(`${JSON.stringify({
+      type: 'MODIFIED',
+      object: fakeExternalSecretObject
+    })}\n`)
+
+    mockedStream.push(`${JSON.stringify({
+      type: 'ADDED',
+      object: fakeExternalSecretObject
+    })}\n`)
+
+    mockedStream.push(`${JSON.stringify({
+      type: 'DELETED',
+      object: fakeExternalSecretObject
+    })}\n`)
+
+    mockedStream.push(`${JSON.stringify({
+      type: 'DELETED_ALL'
+    })}\n`)
+
+    const modifiedEvent = await events.next()
+    expect(modifiedEvent.value.type).is.equal('MODIFIED')
+    expect(modifiedEvent.value.object).is.deep.equal(fakeExternalSecretObject)
+
     const addedEvent = await events.next()
     expect(addedEvent.value.type).is.equal('ADDED')
     expect(addedEvent.value.object).is.deep.equal(fakeExternalSecretObject)
-    events.return(null)
+
+    const deletedEvent = await events.next()
+    expect(deletedEvent.value.type).is.equal('DELETED')
+    expect(deletedEvent.value.object).is.deep.equal(fakeExternalSecretObject)
+
+    const deletedAllEvent = await events.next()
+    expect(deletedAllEvent.value.type).is.equal('DELETED_ALL')
+    expect(deletedAllEvent.value.object).is.deep.equal(undefined)
   })
 })

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -44,12 +44,13 @@ class Poller {
 
   /**
    * Create Kubernetes secret manifest.
-   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret description.s.
    * @returns {Object} Promise object representing Kubernetes manifest.
    */
-  async _createSecretManifest ({ secretDescriptor }) {
+  async _createSecretManifest () {
+    const secretDescriptor = this._secretDescriptor
     const data = await this._backends[secretDescriptor.backendType]
       .getSecretManifestData({ secretDescriptor })
+
     return {
       apiVersion: 'v1',
       kind: 'Secret',
@@ -71,7 +72,7 @@ class Poller {
   async _poll () {
     this._logger.info('running poll')
     try {
-      await this._upsertKubernetesSecret({ secretDescriptor: this._secretDescriptor })
+      await this._upsertKubernetesSecret()
     } catch (err) {
       this._logger.error('failure while polling the secrets')
       this._logger.error(err)
@@ -80,12 +81,12 @@ class Poller {
 
   /**
    * Create or update Kubernets secret in the cluster.
-   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret description.
    * @returns {Promise} Promise object representing operation result.
    */
-  async _upsertKubernetesSecret ({ secretDescriptor }) {
+  async _upsertKubernetesSecret () {
+    const secretDescriptor = this._secretDescriptor
     const secretName = secretDescriptor.name
-    const secretManifest = await this._createSecretManifest({ secretDescriptor })
+    const secretManifest = await this._createSecretManifest()
     const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
 
     this._logger.info(`upserting secret ${secretName} in ${this._namespace}`)
@@ -99,9 +100,9 @@ class Poller {
 
   /**
    * Checks if secret exists, if not trigger a poll
-   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret description.
    */
-  async _checkForSecret ({ secretDescriptor }) {
+  async _checkForSecret () {
+    const secretDescriptor = this._secretDescriptor
     const secretName = secretDescriptor.name
     const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
 
@@ -126,7 +127,7 @@ class Poller {
     if (forcePoll) {
       this._poll()
     } else {
-      this._checkForSecret({ secretDescriptor: this._secretDescriptor })
+      this._checkForSecret()
     }
 
     this._logger.info('starting poller')

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -119,9 +119,15 @@ class Poller {
    * Start poller.
    * @returns {Object} Poller instance.
    */
-  start () {
+  start ({ forcePoll = false } = {}) {
     if (this._interval) return this
-    this._checkForSecret({ secretDescriptor: this._secretDescriptor })
+
+    if (forcePoll) {
+      this._poll()
+    } else {
+      this._checkForSecret({ secretDescriptor: this._secretDescriptor })
+    }
+
     this._logger.info('starting poller')
     this._interval = setInterval(this._poll.bind(this), this._intervalMilliseconds)
     return this

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -98,11 +98,30 @@ class Poller {
   }
 
   /**
+   * Checks if secret exists, if not trigger a poll
+   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret description.
+   */
+  async _checkForSecret ({ secretDescriptor }) {
+    const secretName = secretDescriptor.name
+    const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
+
+    try {
+      await kubeNamespace.secrets(secretName).get()
+    } catch (err) {
+      if (err.statusCode === 404) {
+        this._logger.info('Secret does not exist, polling right away')
+        this._poll()
+      }
+    }
+  }
+
+  /**
    * Start poller.
    * @returns {Object} Poller instance.
    */
   start () {
     if (this._interval) return this
+    this._checkForSecret({ secretDescriptor: this._secretDescriptor })
     this._logger.info('starting poller')
     this._interval = setInterval(this._poll.bind(this), this._intervalMilliseconds)
     return this

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -117,6 +117,7 @@ class Poller {
 
   /**
    * Start poller.
+   * @param {boolean} forcePoll - Trigger poll right away
    * @returns {Object} Poller instance.
    */
   start ({ forcePoll = false } = {}) {

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -88,7 +88,7 @@ class Poller {
     const secretManifest = await this._createSecretManifest({ secretDescriptor })
     const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
 
-    this._logger.info(`upserting secret ${secretName}`)
+    this._logger.info(`upserting secret ${secretName} in ${this._namespace}`)
     try {
       return await kubeNamespace.secrets.post({ body: secretManifest })
     } catch (err) {

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -10,7 +10,7 @@ describe('Poller', () => {
   let backendMock
   let kubeClientMock
   let loggerMock
-  let poller
+  let pollerFactory
 
   const ownerReference = {
     apiVersion: 'owner-api/v1',
@@ -28,7 +28,15 @@ describe('Poller', () => {
     loggerMock.info = sinon.stub()
     loggerMock.error = sinon.stub()
 
-    poller = new Poller({
+    pollerFactory = (secretDescriptor = {
+      backendType: 'fakeBackendType',
+      name: 'fakeSecretName',
+      properties: [
+        'fakePropertyName1',
+        'fakePropertyName2'
+      ]
+    }) => new Poller({
+      secretDescriptor,
       backends: {
         fakeBackendType: backendMock
       },
@@ -50,21 +58,21 @@ describe('Poller', () => {
     })
 
     it('creates secret manifest', async () => {
+      const poller = pollerFactory({
+        backendType: 'fakeBackendType',
+        name: 'fakeSecretName',
+        properties: [
+          'fakePropertyName1',
+          'fakePropertyName2'
+        ]
+      })
+
       backendMock.getSecretManifestData.resolves({
         fakePropertyName1: 'ZmFrZVByb3BlcnR5VmFsdWUx', // base 64 value
         fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy' // base 64 value
       })
 
-      const secretManifest = await poller._createSecretManifest({
-        secretDescriptor: {
-          backendType: 'fakeBackendType',
-          name: 'fakeSecretName',
-          properties: [
-            'fakePropertyName1',
-            'fakePropertyName2'
-          ]
-        }
-      })
+      const secretManifest = await poller._createSecretManifest()
 
       expect(backendMock.getSecretManifestData.calledWith({
         secretDescriptor: {
@@ -94,12 +102,13 @@ describe('Poller', () => {
   })
 
   describe('_poll', () => {
+    let poller
     beforeEach(() => {
-      poller._secretDescriptor = {
+      poller = pollerFactory({
         backendType: 'fakeBackendType',
         name: 'fakeSecretName1',
         properties: ['fakePropertyName1', 'fakePropertyName2']
-      }
+      })
       poller._upsertKubernetesSecret = sinon.stub()
     })
 
@@ -109,16 +118,7 @@ describe('Poller', () => {
       await poller._poll()
 
       expect(loggerMock.info.calledWith('running poll')).to.equal(true)
-      expect(poller._upsertKubernetesSecret.calledWith({
-        secretDescriptor: {
-          backendType: 'fakeBackendType',
-          name: 'fakeSecretName1',
-          properties: [
-            'fakePropertyName1',
-            'fakePropertyName2'
-          ]
-        }
-      })).to.equal(true)
+      expect(poller._upsertKubernetesSecret.calledWith()).to.equal(true)
     })
 
     it('logs error if storing secret operation fails', async () => {
@@ -132,9 +132,14 @@ describe('Poller', () => {
 
   describe('_upsertKubernetesSecret', () => {
     let kubeNamespaceMock
-    let upsertSecretParams
+    let poller
 
     beforeEach(() => {
+      poller = pollerFactory({
+        backendType: 'fakeBackendType',
+        name: 'fakeSecretName',
+        properties: ['fakePropertyName']
+      })
       kubeNamespaceMock = sinon.mock()
       kubeNamespaceMock.secrets = sinon.stub().returns(kubeNamespaceMock)
       kubeClientMock.api = sinon.mock()
@@ -151,19 +156,12 @@ describe('Poller', () => {
           fakePropertyName: 'ZmFrZVByb3BlcnR5VmFsdWU='
         }
       })
-      upsertSecretParams = {
-        secretDescriptor: {
-          backendType: 'fakeBackendType',
-          name: 'fakeSecretName',
-          properties: ['fakePropertyName']
-        }
-      }
     })
 
     it('creates new secret', async () => {
       kubeNamespaceMock.secrets.post = sinon.stub().resolves()
 
-      await poller._upsertKubernetesSecret(upsertSecretParams)
+      await poller._upsertKubernetesSecret()
 
       expect(kubeNamespaceMock.secrets.post.calledWith({
         body: {
@@ -186,9 +184,10 @@ describe('Poller', () => {
       kubeNamespaceMock.secrets.post = sinon.stub().throws(conflictError)
       kubeNamespaceMock.put = sinon.stub().resolves()
 
-      await poller._upsertKubernetesSecret(upsertSecretParams)
+      await poller._upsertKubernetesSecret()
 
       expect(kubeNamespaceMock.secrets.calledWith('fakeSecretName')).to.equal(true)
+
       expect(kubeNamespaceMock.put.calledWith({
         body: {
           apiVersion: 'v1',
@@ -213,7 +212,7 @@ describe('Poller', () => {
       let error
 
       try {
-        await poller._upsertKubernetesSecret(upsertSecretParams)
+        await poller._upsertKubernetesSecret()
       } catch (err) {
         error = err
       }
@@ -225,8 +224,10 @@ describe('Poller', () => {
 
   describe('start', () => {
     let clock
+    let poller
 
     beforeEach(() => {
+      poller = pollerFactory()
       clock = sinon.useFakeTimers()
       poller._poll = sinon.stub()
     })
@@ -238,7 +239,7 @@ describe('Poller', () => {
 
     it('starts poller', async () => {
       expect(poller._interval).to.equal(null)
-      poller.start()
+      poller.start({ forcePoll: true })
       clock.tick(poller._intervalMilliseconds)
       expect(loggerMock.info.calledWith('starting poller')).to.equal(true)
       expect(poller._interval).to.not.equal(null)
@@ -248,8 +249,10 @@ describe('Poller', () => {
 
   describe('stop', () => {
     let clock
+    let poller
 
     beforeEach(() => {
+      poller = pollerFactory()
       clock = sinon.useFakeTimers()
       poller._poll = sinon.stub()
     })
@@ -259,7 +262,7 @@ describe('Poller', () => {
     })
 
     it('stops poller', async () => {
-      poller.start()
+      poller.start({ forcePoll: true })
       poller.stop()
       expect(loggerMock.info.calledWith('stopping poller')).to.equal(true)
       expect(poller._interval).to.equal(null)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.433.0",
+    "json-stream": "^1.0.0",
     "kubernetes-client": "^8.3.0",
     "lodash.clonedeep": "^4.5.0",
     "make-promises-safe": "^5.0.0",


### PR DESCRIPTION
Currently you can't set a lower events interval than poll interval, as this would result in never polling anything as the poller would be recreated everytime the events are polled.

Not sure if this is the best way to go about it but I tested refactoring so the events poller tracks which external secrets it has seen and yields appropriate events instead of always doing a delete all.

It would be nice if we could in some way instantly poll if an external secret has been modified or added. As if you have a long poll time you would currently have to wait for that to trigger, which feels slow when adding a new external secret. Not sure how to deal with pod restarts tho, as you wouldn't necessarily want to poll instantly when that happens, one alternative would be for the poller to check if the secret exists when started, and if it doesn't then trigger a poll right away.

Let me know what you think :) 

ping @silasbw