### PR TITLE
Upsert secrets immediately for the first time #117 

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -96,7 +96,7 @@ class Daemon {
         }
 
         case 'ADDED': {
-          this._addPoller(descriptor)
+          this._addPoller(descriptor, true)
           break
         }
 


### PR DESCRIPTION
we have noticed that if we set POLLER_INTERVAL_MILLISECONDS=86400000 (24 hours) external secrets are not pulled from aws secrets manager and upserted to secrets immediately after deployment