### PR TITLE
feat: allow setting type in external secret to support other than Opaque secrets

### DIFF
--- a/examples/dockerconfig-example.yml
+++ b/examples/dockerconfig-example.yml
@@ -1,0 +1,10 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dockerhub-secret
+secretDescriptor:
+  backendType: secretsManager
+  type: kubernetes.io/dockerconfigjson
+  data:
+    - key: /development/dockerhub
+      name: .dockerconfigjson

--- a/examples/tls-example.yml
+++ b/examples/tls-example.yml
@@ -6,9 +6,9 @@ secretDescriptor:
   backendType: secretsManager
   type: kubernetes.io/tls
   data:
-    - key: /development/certifcate
+    - key: /development/certificate
       property: crt
       name: tls.crt
-    - key: /development/certifcate
+    - key: /development/certificate
       property: key
       name: tls.key

--- a/examples/tls-example.yml
+++ b/examples/tls-example.yml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: dockerhub-secret
+secretDescriptor:
+  backendType: secretsManager
+  type: kubernetes.io/tls
+  data:
+    - key: /development/certifcate
+      property: crt
+      name: tls.crt
+    - key: /development/certifcate
+      property: key
+      name: tls.key

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -60,7 +60,7 @@ class Poller {
           this._ownerReference
         ]
       },
-      type: 'Opaque',
+      type: secretDescriptor.type || 'Opaque',
       data
     }
   }

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -57,7 +57,7 @@ describe('Poller', () => {
       backendMock.getSecretManifestData = sinon.stub()
     })
 
-    it('creates secret manifest', async () => {
+    it('creates secret manifest - no type (backwards compat)', async () => {
       const poller = pollerFactory({
         backendType: 'fakeBackendType',
         name: 'fakeSecretName',
@@ -93,6 +93,51 @@ describe('Poller', () => {
           ownerReferences: [ownerReference]
         },
         type: 'Opaque',
+        data: {
+          fakePropertyName1: 'ZmFrZVByb3BlcnR5VmFsdWUx', // base 64 value
+          fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy' // base 64 value
+        }
+      })
+    })
+
+    it('creates secret manifest - with type', async () => {
+      const poller = pollerFactory({
+        type: 'dummy-test-type',
+        backendType: 'fakeBackendType',
+        name: 'fakeSecretName',
+        properties: [
+          'fakePropertyName1',
+          'fakePropertyName2'
+        ]
+      })
+
+      backendMock.getSecretManifestData.resolves({
+        fakePropertyName1: 'ZmFrZVByb3BlcnR5VmFsdWUx', // base 64 value
+        fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy' // base 64 value
+      })
+
+      const secretManifest = await poller._createSecretManifest()
+
+      expect(backendMock.getSecretManifestData.calledWith({
+        secretDescriptor: {
+          type: 'dummy-test-type',
+          backendType: 'fakeBackendType',
+          name: 'fakeSecretName',
+          properties: [
+            'fakePropertyName1',
+            'fakePropertyName2'
+          ]
+        }
+      })).to.equal(true)
+
+      expect(secretManifest).deep.equals({
+        apiVersion: 'v1',
+        kind: 'Secret',
+        metadata: {
+          name: 'fakeSecretName',
+          ownerReferences: [ownerReference]
+        },
+        type: 'dummy-test-type',
         data: {
           fakePropertyName1: 'ZmFrZVByb3BlcnR5VmFsdWUx', // base 64 value
           fakePropertyName2: 'ZmFrZVByb3BlcnR5VmFsdWUy' // base 64 value
@@ -151,7 +196,7 @@ describe('Poller', () => {
         metadata: {
           name: 'fakeSecretName'
         },
-        type: 'Opaque',
+        type: 'some-type',
         data: {
           fakePropertyName: 'ZmFrZVByb3BlcnR5VmFsdWU='
         }
@@ -170,7 +215,7 @@ describe('Poller', () => {
           metadata: {
             name: 'fakeSecretName'
           },
-          type: 'Opaque',
+          type: 'some-type',
           data: {
             fakePropertyName: 'ZmFrZVByb3BlcnR5VmFsdWU='
           }
@@ -195,7 +240,7 @@ describe('Poller', () => {
           metadata: {
             name: 'fakeSecretName'
           },
-          type: 'Opaque',
+          type: 'some-type',
           data: {
             fakePropertyName: 'ZmFrZVByb3BlcnR5VmFsdWU='
           }


### PR DESCRIPTION
Possible solution for #109 

> Does this require anything more than being able to set type in the external secret resource?
> 
> Example:
> 
> ```yaml
> apiVersion: kubernetes-client.io/v1
> kind: ExternalSecret
> metadata:
>   name: my-dockerhub-secret
> secretDescriptor:
>   backendType: secretsManager
>   type: kubernetes.io/dockerconfigjson
>   data:
>     - key: /development/mma/dockerhub
>       name: .dockerconfigjson
> ```
> 
> Where the value in backend would be
> 
> ```json
> {"auths":{"https://index.docker.io/v1/":{"auth":"bXljcmVkZW50aWFsczp2ZXJ5LW5pY2UtcGFzc3dvcmQ="}}}
> ```
> 
> Similarly could be done for tls?
> 
> ```yaml
> apiVersion: kubernetes-client.io/v1
> kind: ExternalSecret
> metadata:
>   name: my-tls
> secretDescriptor:
>   backendType: secretsManager
>   type: kubernetes.io/tls
>   data:
>     - key: /development/mma/certifcate
>       property: crt
>       name: tls.crt
>     - key: /development/mma/certifcate
>       property: key
>       name: tls.key
> ```

_Originally posted by @Flydiverny in https://github.com/godaddy/kubernetes-external-secrets/issues/109#issuecomment-514268061_