### PR TITLE
Revert "fix(daemon): Upsert secrets immediately poller added "

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -96,7 +96,7 @@ class Daemon {
         }
 
         case 'ADDED': {
-          this._addPoller(descriptor, true)
+          this._addPoller(descriptor)
           break
         }
 


### PR DESCRIPTION
This reverts commit a986dfba1c96679faab0097b96c5f77e4deb8dca.

I'd like to revert the change introduced in #125 as it causes unnecessary polling when watch stream is disconnected, and causes upserts for all external secrets everytime the pollers are recreated.

I think we can definitely do some kind of improvement here tho.

See discussion in #117 :) 