### PR TITLE
feat: add status subresource with last sync and generation tracking

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -46,7 +46,8 @@ async function main () {
     kubeClient,
     logger,
     metrics,
-    pollerIntervalMilliseconds
+    pollerIntervalMilliseconds,
+    customResourceManifest
   })
 
   const metricsServer = new MetricsServer({

--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -12,6 +12,7 @@ const Daemon = require('../lib/daemon')
 const MetricsServer = require('../lib/metrics-server')
 const Metrics = require('../lib/metrics')
 const { getExternalSecretEvents } = require('../lib/external-secret')
+const PollerFactory = require('../lib/poller-factory')
 
 const {
   backends,
@@ -40,14 +41,19 @@ async function main () {
   const registry = Prometheus.register
   const metrics = new Metrics({ registry })
 
-  const daemon = new Daemon({
+  const pollerFactory = new PollerFactory({
     backends,
-    externalSecretEvents,
     kubeClient,
-    logger,
     metrics,
     pollerIntervalMilliseconds,
-    customResourceManifest
+    customResourceManifest,
+    logger
+  })
+
+  const daemon = new Daemon({
+    externalSecretEvents,
+    logger,
+    pollerFactory
   })
 
   const metricsServer = new MetricsServer({

--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -25,6 +25,9 @@ rules:
   - apiGroups: ["kubernetes-client.io"]
     resources: ["externalsecrets"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets/status"]
+    verbs: ["get", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/custom-resource-manifest.json
+++ b/custom-resource-manifest.json
@@ -2,6 +2,23 @@
   "kind": "CustomResourceDefinition",
   "spec": {
     "scope": "Namespaced",
+    "additionalPrinterColumns": [
+      {
+        "JSONPath": ".status.lastSync",
+        "name": "Last Sync",
+        "type": "date"
+      },
+      {
+        "JSONPath": ".status.status",
+        "name": "status",
+        "type": "string"
+      },
+      {
+        "JSONPath": ".metadata.creationTimestamp",
+        "name": "Age",
+        "type": "date"
+      }
+    ],
     "version": "v1",
     "group": "kubernetes-client.io",
     "names": {
@@ -11,6 +28,9 @@
       "kind": "ExternalSecret",
       "plural": "externalsecrets",
       "singular": "externalsecret"
+    },
+    "subresources": {
+      "status": {}
     }
   },
   "apiVersion": "apiextensions.k8s.io/v1beta1",

--- a/external-secrets.yml
+++ b/external-secrets.yml
@@ -29,6 +29,9 @@ rules:
 - apiGroups: ["kubernetes-client.io"]
   resources: ["externalsecrets"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["kubernetes-client.io"]
+  resources: ["externalsecrets/status"]
+  verbs: ["get", "update"]
 ---
 apiVersion: v1
 kind: Namespace

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -52,10 +52,6 @@ class Daemon {
   _addPoller (descriptor) {
     this._logger.info('spinning up poller for', descriptor.name, 'in', descriptor.namespace)
 
-    if (this._pollers[descriptor.id]) {
-      throw new Error(`Poller for ${descriptor.id} already exists`)
-    }
-
     const poller = this._pollerFactory.createPoller(descriptor)
 
     this._pollers[descriptor.id] = poller.start()
@@ -74,11 +70,7 @@ class Daemon {
           break
         }
 
-        case 'ADDED': {
-          this._addPoller(descriptor)
-          break
-        }
-
+        case 'ADDED':
         case 'MODIFIED': {
           this._removePoller(descriptor.id)
           this._addPoller(descriptor)

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -1,9 +1,5 @@
 'use strict'
 
-/* eslint-disable no-console */
-
-const Poller = require('./poller')
-
 /** Daemon class. */
 class Daemon {
   /**
@@ -15,21 +11,13 @@ class Daemon {
    * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
    */
   constructor ({
-    backends,
     externalSecretEvents,
-    kubeClient,
     logger,
-    metrics,
-    pollerIntervalMilliseconds,
-    customResourceManifest
+    pollerFactory
   }) {
-    this._backends = backends
-    this._kubeClient = kubeClient
     this._externalSecretEvents = externalSecretEvents
     this._logger = logger
-    this._metrics = metrics
-    this._pollerIntervalMilliseconds = pollerIntervalMilliseconds
-    this._customResourceManifest = customResourceManifest
+    this._pollerFactory = pollerFactory
 
     this._pollers = {}
   }
@@ -68,15 +56,7 @@ class Daemon {
       throw new Error(`Poller for ${descriptor.id} already exists`)
     }
 
-    const poller = new Poller({
-      backends: this._backends,
-      intervalMilliseconds: this._pollerIntervalMilliseconds,
-      kubeClient: this._kubeClient,
-      logger: this._logger,
-      metrics: this._metrics,
-      customResourceManifest: this._customResourceManifest,
-      externalSecret: descriptor.externalSecret
-    })
+    const poller = this._pollerFactory.createPoller(descriptor)
 
     this._pollers[descriptor.id] = poller.start()
   }

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -20,7 +20,8 @@ class Daemon {
     kubeClient,
     logger,
     metrics,
-    pollerIntervalMilliseconds
+    pollerIntervalMilliseconds,
+    customResourceManifest
   }) {
     this._backends = backends
     this._kubeClient = kubeClient
@@ -28,6 +29,7 @@ class Daemon {
     this._logger = logger
     this._metrics = metrics
     this._pollerIntervalMilliseconds = pollerIntervalMilliseconds
+    this._customResourceManifest = customResourceManifest
 
     this._pollers = {}
   }
@@ -39,17 +41,8 @@ class Daemon {
    */
   _createPollerDescriptor (externalSecret) {
     const { uid, name, namespace } = externalSecret.metadata
-    // NOTE(jdaeli): hash this in case resource version becomes too long?
-    const secretDescriptor = { ...externalSecret.secretDescriptor, name }
-    const ownerReference = {
-      apiVersion: externalSecret.apiVersion,
-      controller: true,
-      kind: externalSecret.kind,
-      name,
-      uid
-    }
 
-    return { id: uid, namespace, secretDescriptor, ownerReference }
+    return { id: uid, name, namespace, externalSecret }
   }
 
   /**
@@ -68,8 +61,12 @@ class Daemon {
     Object.keys(this._pollers).forEach(pollerId => this._removePoller(pollerId))
   }
 
-  _addPoller (descriptor, forcePoll = false) {
-    this._logger.info('spinning up poller', descriptor)
+  _addPoller (descriptor) {
+    this._logger.info('spinning up poller for', descriptor.name, 'in', descriptor.namespace)
+
+    if (this._pollers[descriptor.id]) {
+      throw new Error(`Poller for ${descriptor.id} already exists`)
+    }
 
     const poller = new Poller({
       backends: this._backends,
@@ -77,12 +74,11 @@ class Daemon {
       kubeClient: this._kubeClient,
       logger: this._logger,
       metrics: this._metrics,
-      namespace: descriptor.namespace,
-      secretDescriptor: descriptor.secretDescriptor,
-      ownerReference: descriptor.ownerReference
+      customResourceManifest: this._customResourceManifest,
+      externalSecret: descriptor.externalSecret
     })
 
-    this._pollers[descriptor.id] = poller.start({ forcePoll })
+    this._pollers[descriptor.id] = poller.start()
   }
 
   /**
@@ -99,13 +95,13 @@ class Daemon {
         }
 
         case 'ADDED': {
-          this._addPoller(descriptor, true)
+          this._addPoller(descriptor)
           break
         }
 
         case 'MODIFIED': {
           this._removePoller(descriptor.id)
-          this._addPoller(descriptor, true)
+          this._addPoller(descriptor)
           break
         }
 

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -5,19 +5,27 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 
 const Daemon = require('./daemon')
-const Poller = require('./poller')
 
 describe('Daemon', () => {
   let daemon
   let loggerMock
+  let pollerMock
+  let pollerFactory
 
   beforeEach(() => {
     loggerMock = sinon.mock()
     loggerMock.info = sinon.stub()
 
+    pollerMock = sinon.mock()
+    pollerMock.start = sinon.stub().returns(pollerMock)
+    pollerMock.stop = sinon.stub().returns(pollerMock)
+
+    pollerFactory = sinon.mock()
+    pollerFactory.createPoller = sinon.stub().returns(pollerMock)
+
     daemon = new Daemon({
       logger: loggerMock,
-      pollerIntervalMilliseconds: 0
+      pollerFactory
     })
   })
 
@@ -26,11 +34,6 @@ describe('Daemon', () => {
   })
 
   it('starts new pollers for external secrets', async () => {
-    sinon.stub(Poller.prototype, 'start')
-      .callsFake(function () { return this })
-    sinon.stub(Poller.prototype, 'stop')
-      .callsFake(function () { return this })
-
     const fakeExternalSecretEvents = (async function * () {
       yield {
         type: 'ADDED',
@@ -49,7 +52,7 @@ describe('Daemon', () => {
     await daemon.start()
     daemon.stop()
 
-    expect(Poller.prototype.start.called).to.equal(true)
-    expect(Poller.prototype.stop.called).to.equal(true)
+    expect(pollerMock.start.called).to.equal(true)
+    expect(pollerMock.stop.called).to.equal(true)
   })
 })

--- a/lib/daemon.test.js
+++ b/lib/daemon.test.js
@@ -55,4 +55,54 @@ describe('Daemon', () => {
     expect(pollerMock.start.called).to.equal(true)
     expect(pollerMock.stop.called).to.equal(true)
   })
+
+  it('tries to remove existing poller on ADDED events', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        type: 'ADDED',
+        object: {
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id'
+          }
+        }
+      }
+    }())
+
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(true)
+    expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
+
+  it('tries to remove existing poller on MODIFIED event', async () => {
+    const fakeExternalSecretEvents = (async function * () {
+      yield {
+        type: 'MODIFIED',
+        object: {
+          metadata: {
+            name: 'foo',
+            namespace: 'foo',
+            uid: 'test-id'
+          }
+        }
+      }
+    }())
+
+    daemon._externalSecretEvents = fakeExternalSecretEvents
+    daemon._addPoller = sinon.mock()
+    daemon._removePoller = sinon.mock()
+
+    await daemon.start()
+    daemon.stop()
+
+    expect(daemon._addPoller.called).to.equal(true)
+    expect(daemon._removePoller.calledWith('test-id')).to.equal(true)
+  })
 })

--- a/lib/poller-factory.js
+++ b/lib/poller-factory.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const Poller = require('./poller')
+
+class PollerFactory {
+  /**
+   * Create PollerFactory.
+   * @param {Object} backends - Backends for fetching secret properties.
+   * @param {Object} kubeClient - Client for interacting with kubernetes cluster.
+   * @param {Object} metrics - Metrics client
+   * @param {Object} customResourceManifest - CRD manifest
+   * @param {Object} logger - Logger for logging stuff.
+   * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
+   */
+  constructor ({
+    backends,
+    kubeClient,
+    metrics,
+    pollerIntervalMilliseconds,
+    customResourceManifest,
+    logger
+  }) {
+    this._logger = logger
+    this._metrics = metrics
+    this._backends = backends
+    this._kubeClient = kubeClient
+    this._pollerIntervalMilliseconds = pollerIntervalMilliseconds
+    this._customResourceManifest = customResourceManifest
+  }
+
+  /**
+   * Create poller
+   * @param {Object} externalSecret - External Secret custom resource oject
+   */
+  createPoller ({ externalSecret }) {
+    const poller = new Poller({
+      backends: this._backends,
+      intervalMilliseconds: this._pollerIntervalMilliseconds,
+      kubeClient: this._kubeClient,
+      logger: this._logger,
+      metrics: this._metrics,
+      customResourceManifest: this._customResourceManifest,
+      externalSecret
+    })
+
+    return poller
+  }
+}
+
+module.exports = PollerFactory

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -99,6 +99,13 @@ class Poller {
     try {
       await this._upsertKubernetesSecret()
       await this._updateStatus('SUCCESS')
+
+      this._metrics.observeSync({
+        name: this._name,
+        namespace: this._namespace,
+        backend: this._secretDescriptor.backendType,
+        status: 'success'
+      })
     } catch (err) {
       this._logger.error(err, `failure while polling the secret ${this._name}`)
       await this._updateStatus(`ERROR, ${err.message}`)
@@ -110,13 +117,6 @@ class Poller {
         status: 'error'
       })
     }
-
-    this._metrics.observeSync({
-      name: this._name,
-      namespace: this._namespace,
-      backend: this._secretDescriptor.backendType,
-      status: 'success'
-    })
   }
 
   /**

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -23,27 +23,47 @@ class Poller {
    * @param {Object} kubeClient - Client for interacting with kubernetes cluster.
    * @param {Object} logger - Logger for logging stuff.
    * @param {string} namespace - Kubernetes namespace.
-   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret descriptor.
+   * @param {Object} customResourceManifest - CRD manifest
+   * @param {Object} externalSecret - ExternalSecret manifest.
+   * @param {Object} metrics - Metrics client.
    */
   constructor ({
     backends,
     intervalMilliseconds,
     kubeClient,
     logger,
-    namespace,
-    secretDescriptor,
-    ownerReference,
-    metrics
+    metrics,
+    customResourceManifest,
+    externalSecret
   }) {
     this._backends = backends
     this._intervalMilliseconds = intervalMilliseconds
     this._kubeClient = kubeClient
     this._logger = logger
-    this._namespace = namespace
-    this._secretDescriptor = secretDescriptor
-    this._ownerReference = ownerReference
+    this._timeoutId = null
     this._metrics = metrics
-    this._interval = null
+    this._customResourceManifest = customResourceManifest
+
+    this._externalSecret = externalSecret
+
+    const { name, uid, namespace } = externalSecret.metadata
+
+    this._secretDescriptor = { ...externalSecret.secretDescriptor, name }
+
+    this._ownerReference = {
+      apiVersion: externalSecret.apiVersion,
+      controller: true,
+      kind: externalSecret.kind,
+      name,
+      uid
+    }
+
+    this._namespace = namespace
+    this._name = name
+
+    this._status = this._kubeClient
+      .apis[this._customResourceManifest.spec.group]
+      .v1.namespaces(this._namespace)[this._customResourceManifest.spec.names.plural](this._name).status
   }
 
   /**
@@ -74,13 +94,17 @@ class Poller {
    * @returns {Promise} Promise object that always resolves.
    */
   async _poll () {
-    this._logger.info(`running poll on the secret ${this._secretDescriptor.name}`)
+    this._logger.info(`running poll on the secret ${this._name}`)
+
     try {
       await this._upsertKubernetesSecret()
+      await this._updateStatus('SUCCESS')
     } catch (err) {
-      this._logger.error(err, `failure while polling the secret ${this._secretDescriptor.name}`)
+      this._logger.error(err, `failure while polling the secret ${this._name}`)
+      await this._updateStatus(`ERROR, ${err.message}`)
+
       this._metrics.observeSync({
-        name: this._secretDescriptor.name,
+        name: this._name,
         namespace: this._namespace,
         backend: this._secretDescriptor.backendType,
         status: 'error'
@@ -88,7 +112,7 @@ class Poller {
     }
 
     this._metrics.observeSync({
-      name: this._secretDescriptor.name,
+      name: this._name,
       namespace: this._namespace,
       backend: this._secretDescriptor.backendType,
       status: 'success'
@@ -100,23 +124,38 @@ class Poller {
    * @returns {Promise} Promise object representing operation result.
    */
   async _upsertKubernetesSecret () {
-    const secretDescriptor = this._secretDescriptor
     const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
 
     // check if namespace is allowed to fetch this secret
     const ns = await kubeNamespace.get()
-    const verdict = this._isPermitted(ns.body, secretDescriptor)
+    const verdict = this._isPermitted(ns.body, this._secretDescriptor)
+
     if (!verdict.allowed) {
-      throw (new Error(`not allowed to fetch secret: ${secretDescriptor.name}: ${verdict.reason}`))
+      throw (new Error(`not allowed to fetch secret: ${this._name}: ${verdict.reason}`))
     }
+
     const secretManifest = await this._createSecretManifest()
-    this._logger.info(`upserting secret ${this._secretDescriptor.name} in ${this._namespace}`)
+    this._logger.info(`upserting secret ${this._name} in ${this._namespace}`)
+
     try {
       return await kubeNamespace.secrets.post({ body: secretManifest })
     } catch (err) {
       if (err.statusCode !== 409) throw err
-      return kubeNamespace.secrets(this._secretDescriptor.name).put({ body: secretManifest })
+      return kubeNamespace.secrets(this._name).put({ body: secretManifest })
     }
+  }
+
+  async _updateStatus (status) {
+    await this._status.put({
+      body: {
+        ...this._externalSecret,
+        status: {
+          lastSync: `${new Date().toISOString()}`,
+          observedGeneration: this._externalSecret.metadata.generation,
+          status
+        }
+      }
+    })
   }
 
   /**
@@ -150,19 +189,49 @@ class Poller {
   }
 
   /**
-   * Checks if secret exists, if not trigger a poll
+   * Checks status of external secret and determines time to next poll
+   * If current observed generation is older than ES generation it will poll right away
+   * otherwise check when it was last polled and set timeout for next poll
    */
-  async _checkForSecret () {
-    const kubeNamespace = this._kubeClient.api.v1.namespaces(this._namespace)
-
+  async _scheduleNextPoll () {
     try {
-      await kubeNamespace.secrets(this._secretDescriptor.name).get()
-    } catch (err) {
-      if (err.statusCode === 404) {
-        this._logger.info(`Secret ${this._secretDescriptor.name} does not exist, polling right away`)
-        this._poll()
+      const {
+        body: {
+          status: {
+            lastSync = null,
+            observedGeneration = 0
+          } = {}
+        } = {}
+      } = await this._status.get()
+
+      const currentGeneration = this._externalSecret.metadata.generation
+
+      if (observedGeneration < currentGeneration) {
+        return this._setNextPoll(0)
       }
+
+      const lastPollTime = Date.parse(lastSync) || 0
+      const elapsedTime = Date.now() - lastPollTime
+      const nextPollIn = Math.max(this._intervalMilliseconds - elapsedTime, 0)
+
+      return this._setNextPoll(nextPollIn)
+    } catch (err) {
+      this._logger.error(err, 'Secret check went boom for %s in %s', this._name, this._namespace)
     }
+  }
+
+  /**
+   * Sets a timeout for the next poll
+   * @param {number} nextPollIn - Trigger poll in this many miliseconds
+   */
+  _setNextPoll (nextPollIn = this._intervalMilliseconds) {
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId)
+      this._timeoutId = null
+    }
+
+    this._timeoutId = setTimeout(this._poll.bind(this), nextPollIn)
+    this._logger.debug('Next poll for %s in %s in %s', this._name, this._namespace, nextPollIn)
   }
 
   /**
@@ -170,17 +239,12 @@ class Poller {
    * @param {boolean} forcePoll - Trigger poll right away
    * @returns {Object} Poller instance.
    */
-  start ({ forcePoll = false } = {}) {
-    if (this._interval) return this
+  start () {
+    if (this._timeoutId) return this
 
-    if (forcePoll) {
-      this._poll()
-    } else {
-      this._checkForSecret()
-    }
+    this._logger.info(`starting poller on the secret ${this._name}`)
+    this._scheduleNextPoll()
 
-    this._logger.info(`starting poller on the secret ${this._secretDescriptor.name}`)
-    this._interval = setInterval(this._poll.bind(this), this._intervalMilliseconds)
     return this
   }
 
@@ -189,10 +253,13 @@ class Poller {
    * @returns {Object} Poller instance.
    */
   stop () {
-    if (!this._interval) return this
-    this._logger.info(`stopping poller on the secret ${this._secretDescriptor.name}`)
-    clearInterval(this._interval)
-    this._interval = null
+    if (!this._timeoutId) return this
+
+    this._logger.info(`stopping poller on the secret ${this._name}`)
+
+    clearTimeout(this._timeoutId)
+    this._timeoutId = null
+
     return this
   }
 }

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -216,7 +216,7 @@ class Poller {
 
       return this._setNextPoll(nextPollIn)
     } catch (err) {
-      this._logger.error(err, 'Secret check went boom for %s in %s', this._name, this._namespace)
+      this._logger.error(err, 'status check went boom for %s in %s', this._name, this._namespace)
     }
   }
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -210,8 +210,16 @@ class Poller {
         return this._setNextPoll(0)
       }
 
+      const now = Date.now()
       const lastPollTime = Date.parse(lastSync) || 0
-      const elapsedTime = Date.now() - lastPollTime
+
+      // If time somehow ends up in the future we schedule a new poll
+      // right away and hopefully get a new saner value
+      if (lastPollTime > now) {
+        return this._setNextPoll(0)
+      }
+
+      const elapsedTime = now - lastPollTime
       const nextPollIn = Math.max(this._intervalMilliseconds - elapsedTime, 0)
 
       return this._setNextPoll(nextPollIn)

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -360,7 +360,7 @@ describe('Poller', () => {
       externalSecretsApiMock.status.get = sinon.stub().throws(error)
 
       await poller._scheduleNextPoll()
-      expect(loggerMock.error.calledWith(error, 'Secret check went boom for %s in %s', 'fakeSecretName', 'fakeNamespace')).to.equal(true)
+      expect(loggerMock.error.calledWith(error, 'status check went boom for %s in %s', 'fakeSecretName', 'fakeNamespace')).to.equal(true)
     })
   })
 

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -302,16 +302,14 @@ describe('Poller', () => {
         expect(poller._setNextPoll.calledWith(poller._intervalMilliseconds - elapsedTime)).to.equal(true)
       })
 
-      it('with last sync in the future - queues poll', async () => {
+      it('with last sync in the future - triggers poll', async () => {
         fakeDate.setFullYear(fakeDate.getFullYear() + 1)
-
-        const elapsedTime = 0
-        clock.tick(elapsedTime)
+        fakeStatus.body.status.lastSync = fakeDate.toISOString()
 
         await poller._scheduleNextPoll()
 
         expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
-        expect(poller._setNextPoll.calledWith(poller._intervalMilliseconds)).to.equal(true)
+        expect(poller._setNextPoll.calledWith(0)).to.equal(true)
       })
 
       it('with old last sync - triggers poll', async () => {

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -12,14 +12,18 @@ describe('Poller', () => {
   let loggerMock
   let metricsMock
   let pollerFactory
+  let fakeCustomResourceManifest
+  let kubeNamespaceMock
+  let externalSecretsApiMock
+  let fakeExternalSecret
 
-  const ownerReference = {
-    apiVersion: 'owner-api/v1',
+  const getOwnerReference = () => ({
+    apiVersion: fakeExternalSecret.apiVersion,
     controller: true,
-    kind: 'MyKind',
-    name: 'fakeSecretName',
-    uid: '4c10d879-2646-40dc-8595-d0b06b60a9ed'
-  }
+    kind: fakeExternalSecret.kind,
+    name: fakeExternalSecret.metadata.name,
+    uid: fakeExternalSecret.metadata.uid
+  })
 
   beforeEach(() => {
     backendMock = sinon.mock()
@@ -28,29 +32,67 @@ describe('Poller', () => {
     metricsMock = sinon.mock()
 
     loggerMock.info = sinon.stub()
+    loggerMock.debug = sinon.stub()
     loggerMock.error = sinon.stub()
 
     metricsMock.observeSync = sinon.stub()
 
+    externalSecretsApiMock = sinon.mock()
+    externalSecretsApiMock.status = sinon.stub()
+    externalSecretsApiMock.status.put = sinon.mock()
+    externalSecretsApiMock.status.get = sinon.mock()
+
+    kubeNamespaceMock = sinon.mock()
+    kubeNamespaceMock.secrets = sinon.stub().returns(kubeNamespaceMock)
+    kubeNamespaceMock.externalsecrets = sinon.stub().returns(externalSecretsApiMock)
+    kubeClientMock.api = sinon.mock()
+    kubeClientMock.api.v1 = sinon.mock()
+    kubeClientMock.api.v1.namespaces = sinon.stub().returns(kubeNamespaceMock)
+    kubeClientMock.apis = sinon.mock()
+    kubeClientMock.apis['kubernetes-client.io'] = sinon.mock()
+    kubeClientMock.apis['kubernetes-client.io'].v1 = sinon.mock()
+    kubeClientMock.apis['kubernetes-client.io'].v1.namespaces = sinon.stub().returns(kubeNamespaceMock)
+
+    fakeCustomResourceManifest = {
+      spec: {
+        group: 'kubernetes-client.io',
+        names: {
+          plural: 'externalsecrets'
+        }
+      }
+    }
+
+    fakeExternalSecret = {
+      apiVersion: 'kubernetes-client.io/v1',
+      kind: 'ExternalSecret',
+      metadata: {
+        namespace: 'fakeNamespace',
+        name: 'fakeSecretName',
+        uid: '4c10d879-2646-40dc-8595-d0b06b60a9ed',
+        generation: 1
+      }
+    }
+
     pollerFactory = (secretDescriptor = {
       backendType: 'fakeBackendType',
-      name: 'fakeSecretName',
       properties: [
         'fakePropertyName1',
         'fakePropertyName2'
       ]
-    }) => new Poller({
-      secretDescriptor,
-      backends: {
-        fakeBackendType: backendMock
-      },
-      metrics: metricsMock,
-      intervalMilliseconds: 5000,
-      kubeClient: kubeClientMock,
-      logger: loggerMock,
-      namespace: 'fakeNamespace',
-      ownerReference
-    })
+    }) => {
+      fakeExternalSecret.secretDescriptor = secretDescriptor
+      return new Poller({
+        backends: {
+          fakeBackendType: backendMock
+        },
+        metrics: metricsMock,
+        intervalMilliseconds: 5000,
+        kubeClient: kubeClientMock,
+        logger: loggerMock,
+        externalSecret: fakeExternalSecret,
+        customResourceManifest: fakeCustomResourceManifest
+      })
+    }
   })
 
   afterEach(() => {
@@ -58,8 +100,17 @@ describe('Poller', () => {
   })
 
   describe('_createSecretManifest', () => {
+    let clock
+
     beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        now: Date.now()
+      })
       backendMock.getSecretManifestData = sinon.stub()
+    })
+
+    afterEach(() => {
+      clock.restore()
     })
 
     it('creates secret manifest - no type (backwards compat)', async () => {
@@ -95,7 +146,7 @@ describe('Poller', () => {
         kind: 'Secret',
         metadata: {
           name: 'fakeSecretName',
-          ownerReferences: [ownerReference]
+          ownerReferences: [getOwnerReference()]
         },
         type: 'Opaque',
         data: {
@@ -140,7 +191,7 @@ describe('Poller', () => {
         kind: 'Secret',
         metadata: {
           name: 'fakeSecretName',
-          ownerReferences: [ownerReference]
+          ownerReferences: [getOwnerReference()]
         },
         type: 'dummy-test-type',
         data: {
@@ -156,10 +207,11 @@ describe('Poller', () => {
     beforeEach(() => {
       poller = pollerFactory({
         backendType: 'fakeBackendType',
-        name: 'fakeSecretName1',
         properties: ['fakePropertyName1', 'fakePropertyName2']
       })
       poller._upsertKubernetesSecret = sinon.stub()
+      poller._setNextPoll = sinon.stub()
+      poller._updateStatus = sinon.stub()
     })
 
     it('polls secrets', async () => {
@@ -169,10 +221,11 @@ describe('Poller', () => {
       expect(loggerMock.info.calledWith(`running poll on the secret ${poller._secretDescriptor.name}`)).to.equal(true)
 
       expect(metricsMock.observeSync.getCall(0).args[0]).to.deep.equal({
-        name: 'fakeSecretName1',
+        name: 'fakeSecretName',
         namespace: 'fakeNamespace',
         backend: 'fakeBackendType',
         status: 'success' })
+      expect(poller._updateStatus.calledWith('SUCCESS')).to.equal(true)
       expect(poller._upsertKubernetesSecret.calledWith()).to.equal(true)
     })
 
@@ -183,16 +236,135 @@ describe('Poller', () => {
       await poller._poll()
 
       expect(metricsMock.observeSync.getCall(0).args[0]).to.deep.equal({
-        name: 'fakeSecretName1',
+        name: 'fakeSecretName',
         namespace: 'fakeNamespace',
         backend: 'fakeBackendType',
         status: 'error' })
+      expect(poller._updateStatus.calledWith(`ERROR, ${error.message}`)).to.equal(true)
       expect(loggerMock.error.calledWith(error, `failure while polling the secret ${poller._secretDescriptor.name}`)).to.equal(true)
     })
   })
 
+  describe('_scheduleNextPoll', () => {
+    let poller
+    let clock
+    let fakeStatus
+    let fakeDate
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers({
+        now: Date.now()
+      })
+
+      poller = pollerFactory({
+        backendType: 'fakeBackendType',
+        properties: ['fakePropertyName']
+      })
+
+      poller._setNextPoll = sinon.stub()
+      poller._poll = sinon.stub()
+
+      fakeDate = new Date()
+
+      fakeStatus = {
+        body: {
+          status: {
+            lastSync: fakeDate.toISOString(),
+            observedGeneration: fakeExternalSecret.metadata.generation
+          }
+        }
+      }
+
+      externalSecretsApiMock.status.get = sinon.stub().resolves(fakeStatus)
+    })
+
+    afterEach(() => {
+      clock.restore()
+    })
+
+    describe('last sync', () => {
+      it('no last sync', async () => {
+        delete fakeStatus.body.status.lastSync
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(0)).to.equal(true)
+      })
+
+      it('with new last sync - queues poll', async () => {
+        const elapsedTime = 2000
+        clock.tick(elapsedTime)
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(poller._intervalMilliseconds - elapsedTime)).to.equal(true)
+      })
+
+      it('with last sync in the future - queues poll', async () => {
+        fakeDate.setFullYear(fakeDate.getFullYear() + 1)
+
+        const elapsedTime = 0
+        clock.tick(elapsedTime)
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(poller._intervalMilliseconds)).to.equal(true)
+      })
+
+      it('with old last sync - triggers poll', async () => {
+        clock.tick(poller._intervalMilliseconds * 2) // greater than poller._intervalMilliseconds
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(0)).to.equal(true)
+      })
+    })
+
+    describe('generation', () => {
+      it('no observed generation', async () => {
+        delete fakeStatus.body.status.observedGeneration
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(0)).to.equal(true)
+      })
+
+      it('with newer observed generation - queues poll', async () => {
+        fakeExternalSecret.metadata.generation = 10
+        fakeStatus.body.status.observedGeneration = 100
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(fakeDate.getTime() - (Date.now() - poller._intervalMilliseconds))).to.equal(true)
+      })
+
+      it('with older observed generation - triggers poll', async () => {
+        fakeExternalSecret.metadata.generation = 10
+        fakeStatus.body.status.observedGeneration = 1
+
+        await poller._scheduleNextPoll()
+
+        expect(externalSecretsApiMock.status.get.calledWith()).to.equal(true)
+        expect(poller._setNextPoll.calledWith(0)).to.equal(true)
+      })
+    })
+
+    it('logs error if it fails', async () => {
+      const error = new Error('something boom')
+      externalSecretsApiMock.status.get = sinon.stub().throws(error)
+
+      await poller._scheduleNextPoll()
+      expect(loggerMock.error.calledWith(error, 'Secret check went boom for %s in %s', 'fakeSecretName', 'fakeNamespace')).to.equal(true)
+    })
+  })
+
   describe('_upsertKubernetesSecret', () => {
-    let kubeNamespaceMock
     let poller
     let fakeNamespace
 
@@ -209,12 +381,7 @@ describe('Poller', () => {
           }
         }
       }
-      kubeNamespaceMock = sinon.mock()
-      kubeNamespaceMock.secrets = sinon.stub().returns(kubeNamespaceMock)
       kubeNamespaceMock.get = sinon.stub().resolves(fakeNamespace)
-      kubeClientMock.api = sinon.mock()
-      kubeClientMock.api.v1 = sinon.mock()
-      kubeClientMock.api.v1.namespaces = sinon.stub().returns(kubeNamespaceMock)
       poller._createSecretManifest = sinon.stub().returns({
         apiVersion: 'v1',
         kind: 'Secret',
@@ -315,49 +482,44 @@ describe('Poller', () => {
   })
 
   describe('start', () => {
-    let clock
     let poller
 
     beforeEach(() => {
       poller = pollerFactory()
-      clock = sinon.useFakeTimers()
-      poller._poll = sinon.stub()
+      poller._scheduleNextPoll = sinon.stub()
     })
 
     afterEach(() => {
       poller.stop()
-      clock.restore()
     })
 
     it('starts poller', async () => {
-      expect(poller._interval).to.equal(null)
-      poller.start({ forcePoll: true })
-      clock.tick(poller._intervalMilliseconds)
+      expect(poller._timeoutId).to.equal(null)
+
+      poller.start()
+
       expect(loggerMock.info.calledWith(`starting poller on the secret ${poller._secretDescriptor.name}`)).to.equal(true)
-      expect(poller._interval).to.not.equal(null)
-      expect(poller._poll.called).to.equal(true)
+      expect(poller._scheduleNextPoll.called).to.equal(true)
     })
   })
 
   describe('stop', () => {
-    let clock
     let poller
 
     beforeEach(() => {
       poller = pollerFactory()
-      clock = sinon.useFakeTimers()
       poller._poll = sinon.stub()
     })
 
-    afterEach(() => {
-      clock.restore()
-    })
-
     it('stops poller', async () => {
-      poller.start({ forcePoll: true })
+      poller._timeoutId = 'some id'
+
+      expect(poller._timeoutId).to.not.equal(null)
+
       poller.stop()
+
       expect(loggerMock.info.calledWith(`stopping poller on the secret ${poller._secretDescriptor.name}`)).to.equal(true)
-      expect(poller._interval).to.equal(null)
+      expect(poller._timeoutId).to.equal(null)
     })
   })
   describe('assume-role permissions', () => {


### PR DESCRIPTION
Currently kubernetes-external-secrets does excessive polling of all external secrets and doesn't respect the polling intervall. Everytime the watch stream disconnects (happens somewhat regularly) all the secrets are regenerated. In our relatively small dev cluster this generates 22 million events to each of KMS, SM and GuardDuty which generates unnecessary billing, and a general waste of compute cycles for the sake of nothing.

This PR uses the status subresource to track generation of external secret, and the last sync time.
Will use these values to determine how to queue up the next poll, either instant or time remaining for next poll intervall to pass. This helps for setting long poll intervals as currently setting something like 24h and having the pod moved or watch stream disconnected would restart the interval from that time, instead of forcing unwanted polls.

Updated CRD to show fields when using kubectl:
![image](https://user-images.githubusercontent.com/326929/68081136-52462400-fe09-11e9-818b-416689a31f93.png)

closes #131 
fixes #117
fixes #153 
fixes #190
start of #185 