### PR TITLE
chore(charts): update charts

### DIFF
--- a/charts/kubernetes-external-secrets/Chart.yaml
+++ b/charts/kubernetes-external-secrets/Chart.yaml
@@ -1,9 +1,16 @@
 apiVersion: v1
 name: kubernetes-external-secrets
 version: 1.0.1
-appVersion: 1.2.0
+appVersion: 1.3.1
 description: Kubernetes External Secrets CustomResourceDefinition
 keywords:
   - kubernetes-external-secrets
   - secrets
 home: https://github.com/godaddy/kubernetes-external-secrets
+sources:
+  - https://github.com/godaddy/kubernetes-external-secrets
+maintainers:
+  - name: jeffpearce
+    email: jxpearce@godaddy.com
+  - name: keweilu
+    email: klu6@godaddy.com

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -41,7 +41,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod      |                                                         |
 | `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod  |                                                         |
 | `image.repository`                   | kubernetes-external-secrets Image name                       | `godaddy/kubernetes-external-secrets`                   |
-| `image.tag`                          | kubernetes-external-secrets Image tag                        | `1.2.0`                                                 |
+| `image.tag`                          | kubernetes-external-secrets Image tag                        | `1.3.1`                                                 |
 | `image.pullPolicy`                   | Image pull policy                                            | `IfNotPresent`                                          |
 | `nameOverride`                   | Override the name of app                                            | `nil`                                          |
 | `fullnameOverride`                   | Override the full name of app                                            | `nil`                                          |

--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -2,12 +2,12 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "kubernetes-external-secrets.fullname" . }}
+  name: {{ include "kubernetes-external-secrets.fullname" . }}
   labels:
-    app: {{ template "kubernetes-external-secrets.name" . }}
-    chart: {{ template "kubernetes-external-secrets.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -26,12 +26,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kubernetes-external-secrets.fullname" . }}
+  name: {{ include "kubernetes-external-secrets.fullname" . }}
   labels:
-    app: {{ template "kubernetes-external-secrets.name" . }}
-    chart: {{ template "kubernetes-external-secrets.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/kubernetes-external-secrets/templates/serviceaccount.yaml
+++ b/charts/kubernetes-external-secrets/templates/serviceaccount.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "kubernetes-external-secrets.serviceAccountName" . }}
+  name: {{ include "kubernetes-external-secrets.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "kubernetes-external-secrets.name" . }}
-    chart: {{ template "kubernetes-external-secrets.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -8,7 +8,7 @@ env:
   POLLER_INTERVAL_MILLISECONDS: 10000
 
 # Create environment variables from exists k8s secrets
-#envVarsFromSecret:
+# envVarsFromSecret:
 #  AWS_ACCESS_KEY_ID:
 #    secretKeyRef: aws-credentials
 #    key: id


### PR DESCRIPTION
As stated in this PR https://github.com/helm/helm/pull/6095, the stable repository is going to be removed and they suggest an alternative way to use Helm Hub https://github.com/helm/hub. This PR updates charts base on the original PR to helm/charts repo https://github.com/helm/charts/pull/15465. Then the charts will be hosted in our repo and will make a PR to Helm Hub to add kubernetes-external-secrets helm charts