### PR TITLE
Added parameter to control secrets backend polling

### DIFF
--- a/bin/daemon.js
+++ b/bin/daemon.js
@@ -16,7 +16,8 @@ const {
   customResourceManager,
   customResourceManifest,
   logger,
-  pollerIntervalMilliseconds
+  pollerIntervalMilliseconds,
+  trackSecretBackend
 } = require('../config')
 
 async function main () {
@@ -38,7 +39,8 @@ async function main () {
     externalSecretEvents,
     kubeClient,
     logger,
-    pollerIntervalMilliseconds
+    pollerIntervalMilliseconds,
+    trackSecretBackend
   })
 
   logger.info('starting app')

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -32,10 +32,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
           {{- range $name, $value := .Values.env }}
-          {{- if not (empty $value) }}
           - name: {{ $name | quote }}
             value: {{ $value | quote }}
-          {{- end }}
           {{- end }}
           # Params for env vars populated from k8s secrets
           {{- range $key, $value := .Values.envVarsFromSecret }}

--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["get", "create", "update"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create"]

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -6,6 +6,7 @@
 env:
   AWS_REGION: us-west-2
   POLLER_INTERVAL_MILLISECONDS: 10000
+  TRACK_SECRET_BACKEND: true
 
 # Create environment variables from exists k8s secrets
 # envVarsFromSecret:

--- a/config/environment.js
+++ b/config/environment.js
@@ -20,12 +20,13 @@ const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 const trackSecretBackend = process.env.TRACK_SECRET_BACKEND
-  ? (process.env.TRACK_SECRET_BACKEND == 'true') : true
+  ? (process.env.TRACK_SECRET_BACKEND === 'true') : true
 
 const logLevel = process.env.LOG_LEVEL || 'info'
 
 module.exports = {
   environment,
   pollerIntervalMilliseconds,
+  trackSecretBackend,
   logLevel
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,9 @@ if (environment === 'development') {
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
+const trackSecretBackend = process.env.TRACK_SECRET_BACKEND
+  ? (process.env.TRACK_SECRET_BACKEND == 'true') : true
+
 const logLevel = process.env.LOG_LEVEL || 'info'
 
 module.exports = {

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -13,19 +13,22 @@ class Daemon {
    * @param {Object} externalSecretEvents - Stream of external secret events.
    * @param {Object} logger - Logger for logging stuff.
    * @param {number} pollerIntervalMilliseconds - Interval time in milliseconds for polling secret properties.
+   * @param {boolean} trackSecretBackend - Keep tracking secret backend value changes after initial creation
    */
   constructor ({
     backends,
     externalSecretEvents,
     kubeClient,
     logger,
-    pollerIntervalMilliseconds
+    pollerIntervalMilliseconds,
+    trackSecretBackend
   }) {
     this._backends = backends
     this._kubeClient = kubeClient
     this._externalSecretEvents = externalSecretEvents
     this._logger = logger
     this._pollerIntervalMilliseconds = pollerIntervalMilliseconds
+    this._trackSecretBackend = trackSecretBackend
 
     this._pollers = {}
   }
@@ -96,13 +99,13 @@ class Daemon {
         }
 
         case 'ADDED': {
-          this._addPoller(descriptor, true)
+          this._addPoller(descriptor, this._trackSecretBackend)
           break
         }
 
         case 'MODIFIED': {
           this._removePoller(descriptor.id)
-          this._addPoller(descriptor, true)
+          this._addPoller(descriptor, this._trackSecretBackend)
           break
         }
 

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -121,12 +121,13 @@ class Poller {
 
     if (forcePoll) {
       this._poll()
+
+      this._logger.info(`starting poller on the secret ${this._secretDescriptor.name}`)
+      this._interval = setInterval(this._poll.bind(this), this._intervalMilliseconds)
     } else {
       this._checkForSecret()
     }
 
-    this._logger.info(`starting poller on the secret ${this._secretDescriptor.name}`)
-    this._interval = setInterval(this._poll.bind(this), this._intervalMilliseconds)
     return this
   }
 


### PR DESCRIPTION
Trying to address AWS SSM rate limits issue. We are not planning to change/rotate secrets value on the fly. Will are planning to address secret rotation by updating versioning into secret name.

Better fix for https://github.com/godaddy/kubernetes-external-secrets/issues/117

co-author @max-lobur, please review