### PR TITLE
Add support for serviceaccount annotations

### DIFF
--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ template "kubernetes-external-secrets.fullname" . }}
+      serviceAccountName: {{ template "kubernetes-external-secrets.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/kubernetes-external-secrets/templates/serviceaccount.yaml
+++ b/charts/kubernetes-external-secrets/templates/serviceaccount.yaml
@@ -4,6 +4,9 @@ kind: ServiceAccount
 metadata:
   name: {{ include "kubernetes-external-secrets.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
     helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -25,6 +25,8 @@ rbac:
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Specifies annotations for this service account
+  annotations:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
EKS supports specifying an IAM Role to a service account. (see #161 and https://docs.aws.amazon.com/en_pv/eks/latest/userguide/iam-roles-for-service-accounts.html)
Currently we have to create a seperate service account and link it to the deployment.

This PR adds support to add this annotation directly using the chart.

Should fix #170 