### PR TITLE
Retrieve binary secrets from AWS Secrets Manager

### DIFF
--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -45,7 +45,7 @@ class SecretsManagerBackend extends KVBackend {
       return data.SecretString
     }
 
-    this._logger(`Unexpected data from Secrets Manager secret ${secretKey}`)
+    this._logger.error(`Unexpected data from Secrets Manager secret ${secretKey}`)
     return null
   }
 }

--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -39,10 +39,14 @@ class SecretsManagerBackend extends KVBackend {
       .getSecretValue({ SecretId: secretKey })
       .promise()
 
-    if (data.SecretString === undefined) {
+    if ('SecretBinary' in data) {
       return data.SecretBinary
+    } else if ('SecretString' in data) {
+      return data.SecretString
     }
-    return data.SecretString
+
+    this._logger(`Unexpected data from Secrets Manager secret ${secretKey}`)
+    return null
   }
 }
 

--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -39,6 +39,9 @@ class SecretsManagerBackend extends KVBackend {
       .getSecretValue({ SecretId: secretKey })
       .promise()
 
+    if (data.SecretString === undefined) {
+      return data.SecretBinary
+    }
     return data.SecretString
   }
 }

--- a/lib/backends/secrets-manager-backend.test.js
+++ b/lib/backends/secrets-manager-backend.test.js
@@ -55,6 +55,23 @@ describe('SecretsManagerBackend', () => {
       expect(secretPropertyValue).equals('fakeSecretPropertyValue')
     })
 
+    it('returns binary secret', async () => {
+      getSecretValuePromise.promise.resolves({
+        SecretBinary: Buffer.from('fakeSecretPropertyValue', 'utf-8').toString('base64')
+      })
+
+      const secretPropertyValue = await secretsManagerBackend._get({
+        secretKey: 'fakeSecretKey'
+      })
+
+      expect(clientMock.getSecretValue.calledWith({
+        SecretId: 'fakeSecretKey'
+      })).to.equal(true)
+      expect(clientFactoryMock.getCall(0).args).deep.equals([])
+      expect(assumeRoleMock.callCount).equals(0)
+      expect(secretPropertyValue).equals('ZmFrZVNlY3JldFByb3BlcnR5VmFsdWU=')
+    })
+
     it('returns secret property value assuming a role', async () => {
       getSecretValuePromise.promise.resolves({
         SecretString: 'fakeAssumeRoleSecretValue'

--- a/lib/backends/secrets-manager-backend.test.js
+++ b/lib/backends/secrets-manager-backend.test.js
@@ -57,7 +57,7 @@ describe('SecretsManagerBackend', () => {
 
     it('returns binary secret', async () => {
       getSecretValuePromise.promise.resolves({
-        SecretBinary: Buffer.from('fakeSecretPropertyValue', 'utf-8').toString('base64')
+        SecretBinary: Buffer.from('fakeSecretPropertyValue', 'utf-8')
       })
 
       const secretPropertyValue = await secretsManagerBackend._get({
@@ -69,7 +69,7 @@ describe('SecretsManagerBackend', () => {
       })).to.equal(true)
       expect(clientFactoryMock.getCall(0).args).deep.equals([])
       expect(assumeRoleMock.callCount).equals(0)
-      expect(secretPropertyValue).equals('ZmFrZVNlY3JldFByb3BlcnR5VmFsdWU=')
+      expect(secretPropertyValue.toString()).equals('fakeSecretPropertyValue')
     })
 
     it('returns secret property value assuming a role', async () => {


### PR DESCRIPTION
Should fix https://github.com/godaddy/kubernetes-external-secrets/issues/149 issue