### PR TITLE
Support for Hashicorp Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `env.METRICS_PORT`                        | Specify the port for the prometheus metrics server           | `3001`                                                  |
 | `env.ROLE_PERMITTED_ANNOTATION`           | Specify the annotation key where to lookup the role arn permission boundaries | `iam.amazonaws.com/permitted`          |
 | `env.POLLER_INTERVAL_MILLISECONDS`        | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod           | `10000`                                                 |
+| `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault               | `http://127.0.0.1:8200                                  |
 | `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod      |                                                         |
 | `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod  |                                                         |
 | `image.repository`                        | kubernetes-external-secrets Image name                       | `godaddy/kubernetes-external-secrets`                   |

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ data:
 
 ## Backends
 
-kubernetes-external-secrets supports both AWS Secrets Manager and AWS System Manager.
+kubernetes-external-secrets supports AWS Secrets Manager, AWS System Manager, and Hashicorp Vault.
 
 ### AWS Secrets Manager
 
@@ -287,6 +287,34 @@ spec:
     - key: hello-service/migration-credentials
       name: password
       property: password
+```
+
+### Hashicorp Vault
+
+kubernetes-external-secrets supports fetching secrets from [Hashicorp Vault](https://www.vaultproject.io/), using the [Kubernetes authentication method](https://www.vaultproject.io/docs/auth/kubernetes.html).
+
+You will need to set the `VAULT_ADDR` environment variables so that kubernetes-external-secrets knows which endpoint to connect to, then create `ExternalSecret` definitions as follows:
+
+```yml
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: hello-vault-service
+secretDescriptor:
+  backendType: vault
+  # Your authentication mount point, e.g. "kubernetes"
+  vaultMountPoint: my-kubernetes-vault-mount-point
+  # The vault role that will be used to fetch the secrets
+  # This role will need to be bound to kubernetes-external-secret's ServiceAccount; see Vault's documentation:
+  # https://www.vaultproject.io/docs/auth/kubernetes.html
+  vaultRole: my-vault-role
+  properties:
+  # The full path of the secret to read, as in `vault read secret/data/hello-service/credentials`
+  - key: secret/data/hello-service/credentials
+    property: password
+  # Properties are matched individually. If you have several properties in your Vault secret, you will need to add them all separately
+  - key: secret/data/hello-service/credentials
+    property: api-key
 ```
 
 ## Metrics

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: hello-vault-service
-secretDescriptor:
+spec:
   backendType: vault
   # Your authentication mount point, e.g. "kubernetes"
   vaultMountPoint: my-kubernetes-vault-mount-point
@@ -310,11 +310,13 @@ secretDescriptor:
   # https://www.vaultproject.io/docs/auth/kubernetes.html
   vaultRole: my-vault-role
   data:
-  # The full path of the secret to read, as in `vault read secret/data/hello-service/credentials`
-  - key: secret/data/hello-service/credentials
+  - name: password
+    # The full path of the secret to read, as in `vault read secret/data/hello-service/credentials`
+    key: secret/data/hello-service/credentials
     property: password
-  # Properties are matched individually. If you have several properties in your Vault secret, you will need to add them all separately
-  - key: secret/data/hello-service/credentials
+  # Vault values are matched individually. If you have several keys in your Vault secret, you will need to add them all separately
+  - name: api-key
+    key: secret/data/hello-service/credentials
     property: api-key
 ```
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ secretDescriptor:
   # This role will need to be bound to kubernetes-external-secret's ServiceAccount; see Vault's documentation:
   # https://www.vaultproject.io/docs/auth/kubernetes.html
   vaultRole: my-vault-role
-  properties:
+  data:
   # The full path of the secret to read, as in `vault read secret/data/hello-service/credentials`
   - key: secret/data/hello-service/credentials
     property: password

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
                 name: {{ $value.secretKeyRef | quote }}
                 key: {{ $value.key | quote }}
           {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubernetes-external-secrets/templates/rbac.yaml
+++ b/charts/kubernetes-external-secrets/templates/rbac.yaml
@@ -46,4 +46,22 @@ subjects:
   - name: {{ template "kubernetes-external-secrets.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubernetes-external-secrets.fullname" . }}-auth
+  labels:
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- name: {{ template "kubernetes-external-secrets.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  kind: ServiceAccount
 {{- end -}}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -8,6 +8,7 @@ env:
   POLLER_INTERVAL_MILLISECONDS: 10000
   LOG_LEVEL: info
   METRICS_PORT: 3001
+  VAULT_ADDR: http://127.0.0.1:8200
 
 # Create environment variables from exists k8s secrets
 # envVarsFromSecret:

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,7 +16,7 @@ if (environment === 'development') {
   require('dotenv').config()
 }
 
-const vaultEndpoint = process.env.VAULT_ENDPOINT || 'http://127.0.0.1:8200'
+const vaultEndpoint = process.env.VAULT_ADDR || 'http://127.0.0.1:8200'
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,6 +16,7 @@ if (environment === 'development') {
   require('dotenv').config()
 }
 
+const vaultEndpoint = process.env.VAULT_ENDPOINT || 'http://127.0.0.1:8200'
 const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
@@ -26,6 +27,7 @@ const rolePermittedAnnotation = process.env.ROLE_PERMITTED_ANNOTATION || 'iam.am
 const metricsPort = process.env.METRICS_PORT || 3001
 
 module.exports = {
+  vaultEndpoint,
   environment,
   pollerIntervalMilliseconds,
   metricsPort,

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const vault = require('node-vault')
 const kube = require('kubernetes-client')
 const KubeRequest = require('kubernetes-client/backends/request')
 const pino = require('pino')
@@ -10,6 +11,7 @@ const CustomResourceManager = require('../lib/custom-resource-manager')
 const customResourceManifest = require('../custom-resource-manifest.json')
 const SecretsManagerBackend = require('../lib/backends/secrets-manager-backend')
 const SystemManagerBackend = require('../lib/backends/system-manager-backend')
+const VaultBackend = require('../lib/backends/vault-backend')
 
 const kubeconfig = new kube.KubeConfig()
 kubeconfig.loadFromDefault()
@@ -38,9 +40,12 @@ const systemManagerBackend = new SystemManagerBackend({
   assumeRole: awsConfig.assumeRole,
   logger
 })
+const vaultClient = vault({apiVersion: 'v1', endpoint: envConfig.vaultEndpoint})
+const vaultBackend = new VaultBackend({ client: vaultClient, logger })
 const backends = {
   secretsManager: secretsManagerBackend,
-  systemManager: systemManagerBackend
+  systemManager: systemManagerBackend,
+  vault: vaultBackend
 }
 
 // backwards compatibility

--- a/config/index.js
+++ b/config/index.js
@@ -40,7 +40,7 @@ const systemManagerBackend = new SystemManagerBackend({
   assumeRole: awsConfig.assumeRole,
   logger
 })
-const vaultClient = vault({apiVersion: 'v1', endpoint: envConfig.vaultEndpoint})
+const vaultClient = vault({ apiVersion: 'v1', endpoint: envConfig.vaultEndpoint })
 const vaultBackend = new VaultBackend({ client: vaultClient, logger })
 const backends = {
   secretsManager: secretsManagerBackend,

--- a/examples/hello-service-external-secret-vault.yml
+++ b/examples/hello-service-external-secret-vault.yml
@@ -1,0 +1,11 @@
+apiVersion: 'kubernetes-client.io/v1'
+kind: ExternalSecret
+metadata:
+  name: hello-service
+secretDescriptor:
+  backendType: vault
+  vaultMountPoint: my-kubernetes-vault-mount-point
+  vaultRole: my-vault-role
+  properties:
+    - key: hello-service/password
+      name: password

--- a/examples/hello-service-external-secret-vault.yml
+++ b/examples/hello-service-external-secret-vault.yml
@@ -6,6 +6,6 @@ secretDescriptor:
   backendType: vault
   vaultMountPoint: my-kubernetes-vault-mount-point
   vaultRole: my-vault-role
-  properties:
+  data:
     - key: secret/data/hello-service/password
       property: password

--- a/examples/hello-service-external-secret-vault.yml
+++ b/examples/hello-service-external-secret-vault.yml
@@ -7,5 +7,5 @@ secretDescriptor:
   vaultMountPoint: my-kubernetes-vault-mount-point
   vaultRole: my-vault-role
   properties:
-    - key: hello-service/password
-      name: password
+    - key: secret/data/hello-service/password
+      property: password

--- a/examples/hello-service-external-secret-vault.yml
+++ b/examples/hello-service-external-secret-vault.yml
@@ -2,10 +2,11 @@ apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
   name: hello-service
-secretDescriptor:
+spec:
   backendType: vault
   vaultMountPoint: my-kubernetes-vault-mount-point
   vaultRole: my-vault-role
   data:
-    - key: secret/data/hello-service/password
+    - name: password
+      key: secret/data/hello-service/password
       property: password

--- a/external-secrets.yml
+++ b/external-secrets.yml
@@ -36,6 +36,19 @@ rules:
   resources: ["externalsecrets/status"]
   verbs: ["get", "update"]
 ---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets-cluster-role-binding-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-external-secrets-service-account
+  namespace: kubernetes-external-secrets
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -15,7 +15,7 @@ class VaultBackend extends KVBackend {
     this._serviceAccountToken
   }
 
-   /**
+  /**
    * Fetch Kubernetes service account token.
    * @returns {string} String representing the token of the service account running this pod.
    */
@@ -27,7 +27,7 @@ class VaultBackend extends KVBackend {
     return this._serviceAccountToken
   }
 
-   /**
+  /**
    * Fetch Kubernetes secret property values.
    * @param {Object[]} secretProperties - Kubernetes secret properties.
    * @param {string} secretProperties[].key - Secret key in the backend.
@@ -38,13 +38,16 @@ class VaultBackend extends KVBackend {
    */
   _fetchSecretPropertyValues ({ vaultMountPoint, vaultRole, jwt, externalData }) {
     return Promise.all(externalData.map(async secretProperty => {
-      this._logger.info(`fetching secret property ${secretProperty.name}`)
+      this._logger.info(`fetching secret property ${secretProperty.key}`)
       const value = await this._get({ vaultMountPoint: vaultMountPoint, vaultRole: vaultRole, jwt: jwt, secretKey: secretProperty.key })
 
+      // If we're fetching only one property of this secret: assume it's a string already
       if ('property' in secretProperty) {
         return value[secretProperty.property]
       }
-      return value
+
+      // Otherwise, it'll be a json-formatted key->value object that we need to stringify
+      return JSON.stringify(value)
     }))
   }
 
@@ -68,9 +71,10 @@ class VaultBackend extends KVBackend {
       this._client.tokenRenewSelf()
     }
 
+    this._logger.debug(`reading secret key ${secretKey} from vault`)
     var secretResponse = await this._client.read(secretKey)
-    
-    return JSON.stringify(secretResponse.data.data)
+
+    return secretResponse.data.data
   }
 
   /**
@@ -83,15 +87,15 @@ class VaultBackend extends KVBackend {
     // Use secretDescriptor.properties to be backwards compatible.
     const vaultMountPoint = secretDescriptor.vaultMountPoint
     const vaultRole = secretDescriptor.vaultRole
-    
+
     const externalData = secretDescriptor.data || secretDescriptor.properties
     const secretPropertyValues = await this._fetchSecretPropertyValues({
       vaultMountPoint,
       vaultRole,
       externalData
     })
-    externalData.forEach((secretProperty, index) => {
-      data[secretProperty.name] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
+    externalData.forEach((secret, index) => {
+      data[secret.name] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
     })
     return data
   }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -77,10 +77,10 @@ class VaultBackend extends KVBackend {
    */
   async getSecretManifestData ({ secretDescriptor }) {
     const data = {}
-    // Use secretDescriptor.properties to be backwards compatible.
     const vaultMountPoint = secretDescriptor.vaultMountPoint
     const vaultRole = secretDescriptor.vaultRole
 
+    // Also support secretDescriptor.properties to be backwards compatible.
     const externalData = secretDescriptor.data || secretDescriptor.properties
     const secretPropertyValues = await this._fetchSecretPropertyValues({
       vaultMountPoint,

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -20,7 +20,7 @@ class VaultBackend extends KVBackend {
    */
   _fetchServiceAccountToken () {
     if (!this._serviceAccountToken) {
-      var fs = require('fs')
+      const fs = require('fs')
       this._serviceAccountToken = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8')
     }
     return this._serviceAccountToken
@@ -51,9 +51,9 @@ class VaultBackend extends KVBackend {
    */
   async _get ({ vaultMountPoint, vaultRole, secretKey }) {
     if (!this._client.token) {
-      var jwt = this._fetchServiceAccountToken()
+      const jwt = this._fetchServiceAccountToken()
       this._logger.debug(`fetching new token from vault`)
-      var vault = await this._client.kubernetesLogin({
+      const vault = await this._client.kubernetesLogin({
         mount_point: vaultMountPoint,
         role: vaultRole,
         jwt: jwt
@@ -65,7 +65,7 @@ class VaultBackend extends KVBackend {
     }
 
     this._logger.debug(`reading secret key ${secretKey} from vault`)
-    var secretResponse = await this._client.read(secretKey)
+    const secretResponse = await this._client.read(secretKey)
 
     return secretResponse.data.data
   }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -12,7 +12,6 @@ class VaultBackend extends KVBackend {
   constructor ({ client, logger }) {
     super({ logger })
     this._client = client
-    this._serviceAccountToken
   }
 
   /**
@@ -21,8 +20,8 @@ class VaultBackend extends KVBackend {
    */
   _fetchServiceAccountToken () {
     if (!this._serviceAccountToken) {
-      var fs = require('fs');
-      this._serviceAccountToken = fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/token", "utf8")
+      var fs = require('fs')
+      this._serviceAccountToken = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8')
     }
     return this._serviceAccountToken
   }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -2,7 +2,7 @@
 
 const KVBackend = require('./kv-backend')
 
-/** Secrets Manager backend class. */
+/** Vault backend class. */
 class VaultBackend extends KVBackend {
   /**
    * Create Vault backend.

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -41,13 +41,7 @@ class VaultBackend extends KVBackend {
       this._logger.info(`fetching secret property ${secretProperty.key}`)
       const value = await this._get({ vaultMountPoint: vaultMountPoint, vaultRole: vaultRole, jwt: jwt, secretKey: secretProperty.key })
 
-      // If we're fetching only one property of this secret: assume it's a string already
-      if ('property' in secretProperty) {
-        return value[secretProperty.property]
-      }
-
-      // Otherwise, it'll be a json-formatted key->value object that we need to stringify
-      return JSON.stringify(value)
+      return value[secretProperty.property]
     }))
   }
 

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -1,0 +1,100 @@
+'use strict'
+
+const KVBackend = require('./kv-backend')
+
+/** Secrets Manager backend class. */
+class VaultBackend extends KVBackend {
+  /**
+   * Create Vault backend.
+   * @param {Object} client - Client for interacting with Vault.
+   * @param {Object} logger - Logger for logging stuff.
+   */
+  constructor ({ client, logger }) {
+    super({ logger })
+    this._client = client
+    this._serviceAccountToken
+  }
+
+   /**
+   * Fetch Kubernetes service account token.
+   * @returns {string} String representing the token of the service account running this pod.
+   */
+  _fetchServiceAccountToken () {
+    if (!this._serviceAccountToken) {
+      var fs = require('fs');
+      this._serviceAccountToken = fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/token", "utf8")
+    }
+    return this._serviceAccountToken
+  }
+
+   /**
+   * Fetch Kubernetes secret property values.
+   * @param {Object[]} secretProperties - Kubernetes secret properties.
+   * @param {string} secretProperties[].key - Secret key in the backend.
+   * @param {string} secretProperties[].name - Kubernetes Secret property name.
+   * @param {string} secretProperties[].property - If the backend secret is an
+   *   object, this is the property name of the value to use.
+   * @returns {Promise} Promise object representing secret property values.
+   */
+  _fetchSecretPropertyValues ({ vaultMountPoint, vaultRole, jwt, externalData }) {
+    return Promise.all(externalData.map(async secretProperty => {
+      this._logger.info(`fetching secret property ${secretProperty.name}`)
+      const value = await this._get({ vaultMountPoint: vaultMountPoint, vaultRole: vaultRole, jwt: jwt, secretKey: secretProperty.key })
+
+      if ('property' in secretProperty) {
+        return value[secretProperty.property]
+      }
+      return value
+    }))
+  }
+
+  /**
+   * Get secret property value from Vault.
+   * @param {string} secretKey - Key used to store secret property value in Vault.
+   * @returns {Promise} Promise object representing secret property value.
+   */
+  async _get ({ vaultMountPoint, vaultRole, secretKey }) {
+    if (!this._client.token) {
+      var jwt = this._fetchServiceAccountToken()
+      this._logger.debug(`fetching new token from vault`)
+      var vault = await this._client.kubernetesLogin({
+        mount_point: vaultMountPoint,
+        role: vaultRole,
+        jwt: jwt
+      })
+      this._client.token = vault.auth.client_token
+    } else {
+      this._logger.debug(`renewing existing token from vault`)
+      this._client.tokenRenewSelf()
+    }
+
+    var secretResponse = await this._client.read(secretKey)
+    
+    return JSON.stringify(secretResponse.data.data)
+  }
+
+  /**
+   * Fetch Kubernetes secret manifest data.
+   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret descriptor.
+   * @returns {Promise} Promise object representing Kubernetes secret manifest data.
+   */
+  async getSecretManifestData ({ secretDescriptor }) {
+    const data = {}
+    // Use secretDescriptor.properties to be backwards compatible.
+    const vaultMountPoint = secretDescriptor.vaultMountPoint
+    const vaultRole = secretDescriptor.vaultRole
+    
+    const externalData = secretDescriptor.data || secretDescriptor.properties
+    const secretPropertyValues = await this._fetchSecretPropertyValues({
+      vaultMountPoint,
+      vaultRole,
+      externalData
+    })
+    externalData.forEach((secretProperty, index) => {
+      data[secretProperty.name] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
+    })
+    return data
+  }
+}
+
+module.exports = VaultBackend

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -72,23 +72,23 @@ class VaultBackend extends KVBackend {
 
   /**
    * Fetch Kubernetes secret manifest data.
-   * @param {SecretDescriptor} secretDescriptor - Kubernetes secret descriptor.
+   * @param {ExternalSecretSpec} spec - Kubernetes ExternalSecret spec.
    * @returns {Promise} Promise object representing Kubernetes secret manifest data.
    */
-  async getSecretManifestData ({ secretDescriptor }) {
+  async getSecretManifestData ({ spec }) {
     const data = {}
-    const vaultMountPoint = secretDescriptor.vaultMountPoint
-    const vaultRole = secretDescriptor.vaultRole
+    const vaultMountPoint = spec.vaultMountPoint
+    const vaultRole = spec.vaultRole
 
-    // Also support secretDescriptor.properties to be backwards compatible.
-    const externalData = secretDescriptor.data || secretDescriptor.properties
+    // Also support spec.properties to be backwards compatible.
+    const externalData = spec.data || spec.properties
     const secretPropertyValues = await this._fetchSecretPropertyValues({
       vaultMountPoint,
       vaultRole,
       externalData
     })
     externalData.forEach((secret, index) => {
-      data[secret.property] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
+      data[secret.name] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
     })
     return data
   }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -88,7 +88,7 @@ class VaultBackend extends KVBackend {
       externalData
     })
     externalData.forEach((secret, index) => {
-      data[secret.name] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
+      data[secret.property] = (Buffer.from(secretPropertyValues[index], 'utf8')).toString('base64')
     })
     return data
   }

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -1,0 +1,99 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const pino = require('pino')
+
+const VaultBackend = require('./vault-backend')
+const logger = pino({
+  serializers: {
+    err: pino.stdSerializers.err
+  }
+})
+
+describe('VaultBackend', () => {
+  let clientMock
+  let vaultBackend
+
+  beforeEach(() => {
+    clientMock = sinon.mock()
+    // assumeRoleMock = sinon.fake.returns(Promise.resolve(assumeRoleCredentials))
+
+    vaultBackend = new VaultBackend({
+      client: clientMock,
+      logger
+    })
+  })
+
+  describe('_get', () => {
+    let readPromise
+    const mountPoint = 'fakeMountPoint'
+    const role = 'fakeRole'
+    const secretKey = 'fakeSecretKey'
+    const jwt = 'this-is-a-jwt-token'
+
+    beforeEach(() => {
+      readPromise = sinon.mock()
+      readPromise.promise = sinon.stub()
+      clientMock.read = sinon.stub().returns({
+        data: {
+          data: 'fakeSecretPropertyValue'
+        }
+      })
+      clientMock.tokenRenewSelf = sinon.stub().returns(true)
+      clientMock.kubernetesLogin = sinon.stub().returns({
+        auth: {
+          client_token: '1234'
+        }
+      })
+
+      vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
+
+      clientMock.token = undefined
+    })
+
+    it('logs in and returns secret property value', async () => {
+      const secretPropertyValue = await vaultBackend._get({
+        vaultMountPoint: mountPoint,
+        vaultRole: role,
+        secretKey: secretKey
+      })
+
+      // First, we log into Vault...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: 'fakeMountPoint',
+        role: 'fakeRole',
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals('fakeSecretPropertyValue')
+    })
+
+    it('returns secret property value after renewing token if a token exists', async () => {
+      clientMock.token = 'an-existing-token'
+
+      const secretPropertyValue = await vaultBackend._get({
+        vaultMountPoint: mountPoint,
+        vaultRole: role,
+        secretKey: secretKey
+      })
+
+      // No logging into Vault...
+      sinon.assert.notCalled(clientMock.kubernetesLogin)
+
+      // ... but renew the token instead ...
+      sinon.assert.calledOnce(clientMock.tokenRenewSelf)
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals('fakeSecretPropertyValue')
+    })
+  })
+})

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -26,15 +26,12 @@ describe('VaultBackend', () => {
   })
 
   describe('_get', () => {
-    let readPromise
     const mountPoint = 'fakeMountPoint'
     const role = 'fakeRole'
     const secretKey = 'fakeSecretKey'
     const jwt = 'this-is-a-jwt-token'
 
     beforeEach(() => {
-      readPromise = sinon.mock()
-      readPromise.promise = sinon.stub()
       clientMock.read = sinon.stub().returns({
         data: {
           data: 'fakeSecretPropertyValue'

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -18,7 +18,6 @@ describe('VaultBackend', () => {
 
   beforeEach(() => {
     clientMock = sinon.mock()
-    // assumeRoleMock = sinon.fake.returns(Promise.resolve(assumeRoleCredentials))
 
     vaultBackend = new VaultBackend({
       client: clientMock,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4994,6 +4994,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -5091,6 +5096,33 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
+        }
+      }
+    },
+    "node-vault": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.9.11.tgz",
+      "integrity": "sha512-v4xfXtuJuVzQrf8yYh+8/z7yf+UA4O4W0YaOF4rl4TBjK03ryKZnSNnTpfxYTL22pzc9bg7SsLwXi3pWKnACwg==",
+      "requires": {
+        "debug": "3.1.0",
+        "mustache": "^2.2.1",
+        "request": "2.88.0",
+        "request-promise-native": "1.0.7",
+        "tv4": "^1.2.7"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -6221,6 +6253,24 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7002,6 +7052,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -7359,6 +7414,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "make-promises-safe": "^5.0.0",
+    "node-vault": "^0.9.8",
     "pino": "^5.12.0",
     "prom-client": "^11.5.3"
   },


### PR DESCRIPTION
Hello all!

I've been building on @bboerst 's work from [his fork](https://github.com/tunein/kubernetes-external-secrets/tree/vault-backend) to add support for Hashicorp Vault as a backend for external-secrets. 🎉 

I've currently got this working through the bundled Helm Chart, which I've had to tweak a little to add the necessary bits and pieces.

I've also added a first draft of documentation, please let me know what you think / what could be improved!

Fixes #62 