### PR TITLE
Feat: e2e tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+services:
+- docker
 matrix:
   fast_finish: true
   include:
@@ -9,6 +11,13 @@ before_install:
 # package-lock.json was introduced in npm@5
 - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
 - npm install -g greenkeeper-lockfile
+# kubectl, kind, helm
+- curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
+- curl -Lo helm.tgz https://get.helm.sh/helm-v2.16.0-linux-amd64.tar.gz && tar -zxvf helm.tgz && sudo mv linux-amd64/helm /usr/local/bin/helm
 before_script: greenkeeper-lockfile-update
 after_script: greenkeeper-lockfile-upload
 install: npm install
+script:
+- npm test
+- npm run test-e2e

--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -2,23 +2,40 @@
 
 /* eslint-disable no-process-env */
 const AWS = require('aws-sdk')
+const clonedeep = require('lodash.clonedeep')
+const merge = require('lodash.merge')
 
 const localstack = process.env.LOCALSTACK || 0
 
-const secretsManagerConfig = localstack ? { endpoint: 'http://localhost:4584', region: 'us-west-2' } : {}
-const systemManagerConfig = localstack ? { endpoint: 'http://localhost:4583', region: 'us-west-2' } : {}
-const stsConfig = localstack ? { endpoint: 'http://localhost:4592', region: 'us-west-2' } : {}
+let secretsManagerConfig = {}
+let systemManagerConfig = {}
+let stsConfig = {}
+
+if (localstack) {
+  secretsManagerConfig = {
+    endpoint: process.env.LOCALSTACK_SM_URL || 'http://localhost:4584',
+    region: process.env.AWS_REGION || 'us-west-2'
+  }
+  systemManagerConfig = {
+    endpoint: process.env.LOCALSTACK_SSM_URL || 'http://localhost:4583',
+    region: process.env.AWS_REGION || 'us-west-2'
+  }
+  stsConfig = {
+    endpoint: process.env.LOCALSTACK_STS_URL || 'http://localhost:4592',
+    region: process.env.AWS_REGION || 'us-west-2'
+  }
+}
 
 module.exports = {
-  secretsManagerFactory: (opts) => {
+  secretsManagerFactory: (opts = {}) => {
     if (localstack) {
-      opts = secretsManagerConfig
+      opts = merge(clonedeep(opts), secretsManagerConfig)
     }
     return new AWS.SecretsManager(opts)
   },
-  systemManagerFactory: (opts) => {
+  systemManagerFactory: (opts = {}) => {
     if (localstack) {
-      opts = systemManagerConfig
+      opts = merge(clonedeep(opts), systemManagerConfig)
     }
     return new AWS.SSM(opts)
   },

--- a/config/index.js
+++ b/config/index.js
@@ -39,6 +39,7 @@ const systemManagerBackend = new SystemManagerBackend({
   logger
 })
 const backends = {
+  // when adding a new backend, make sure to change the CRD property too
   secretsManager: secretsManagerBackend,
   systemManager: systemManagerBackend
 }
@@ -47,6 +48,7 @@ const backends = {
 backends.secretManager = secretsManagerBackend
 
 module.exports = {
+  awsConfig,
   backends,
   customResourceManager,
   customResourceManifest,

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:12.13.0-alpine
+
+RUN npm install npm@6.4.1 -g
+
+# Setup source directory
+RUN mkdir /app
+WORKDIR /app
+COPY package.json package-lock.json /app/
+RUN npm install
+
+# Copy app to source directory
+COPY . /app
+
+CMD ["/app/node_modules/.bin/mocha", "--timeout", "10000", "/app/e2e/tests/*.test.js"]

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,83 @@
+# e2e tests
+
+## Running e2e tests
+
+Prerequisites:
+* docker
+* kind
+* helm
+* kubectl
+
+Run them from the root of the repository `npm run test-e2e`.
+
+
+## Developing e2e tests
+
+To better understand how they are being run take a look at `run-e2e-suite.sh`.
+
+1. Prepare the environment
+
+```
+kind create cluster \
+  --name es-dev-cluster \
+  --config ./kind.yaml \
+  --image "kindest/node:v1.15.3"
+
+export KUBECONFIG="$(kind get kubeconfig-path --name="es-dev-cluster")"
+
+# build & load images
+docker build -t external-secrets:test -f ../Dockerfile ../
+kind load docker-image --name="es-dev-cluster" external-secrets:test
+
+# prep localstack
+kubectl apply -f ./localstack.deployment.yaml
+
+# deploy external secrets
+helm template ../charts/kubernetes-external-secrets \
+  --set image.repository=external-secrets \
+  --set image.tag=test \
+  --set env.LOG_LEVEL=debug \
+  --set env.LOCALSTACK=true \
+  --set env.LOCALSTACK_SSM_URL=http://ssm \
+  --set env.LOCALSTACK_SM_URL=http://secretsmanager \
+  --set env.AWS_ACCESS_KEY_ID=foobar \
+  --set env.AWS_SECRET_ACCESS_KEY=foobar \
+  --set env.AWS_DEFAULT_REGION=us-east-1 \
+  --set env.AWS_REGION=us-east-1 \
+  --set env.POLLER_INTERVAL_MILLISECONDS=1000 \
+  --set env.LOCALSTACK_STS_URL=http://sts | kubectl apply -f -
+
+# prep e2e test
+kubectl create serviceaccount external-secrets-e2e || true
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --serviceaccount=default:external-secrets-e2e || true
+
+# make sure that everything is running
+kubectl rollout status deploy/localstack
+kubectl rollout status deploy/release-name-kubernetes-external-secrets
+```
+
+2. build image & deploy to start the e2e test
+
+```
+docker build -t external-secrets-e2e:test -f Dockerfile ../
+kind load docker-image --name="es-dev-cluster" external-secrets-e2e:test
+kubectl run \
+  --rm \
+  --attach \
+  --restart=Never \
+  --env="LOCALSTACK=true" \
+  --env="LOCALSTACK_SSM_URL=http://ssm" \
+  --env="LOCALSTACK_SM_URL=http://secretsmanager" \
+  --env="AWS_ACCESS_KEY_ID=foobar" \
+  --env="AWS_SECRET_ACCESS_KEY=foobar" \
+  --env="AWS_DEFAULT_REGION=us-east-1" \
+  --env="AWS_REGION=us-east-1" \
+  --env="LOCALSTACK_STS_URL=http://sts" \
+  --generator=run-pod/v1 \
+  --overrides='{ "apiVersion": "v1", "spec":{"serviceAccountName": "external-secrets-e2e"}}' \
+  e2e --image=external-secrets-e2e:test
+``

--- a/e2e/kind.yaml
+++ b/e2e/kind.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+networking:
+  apiServerPort: 6443
+kubeadmConfigPatches:
+- |
+  apiVersion: kubelet.config.k8s.io/v1beta1
+  kind: KubeletConfiguration
+  metadata:
+    name: config
+  # this is only relevant for btrfs uses
+  # https://github.com/kubernetes/kubernetes/issues/80633#issuecomment-550994513
+  featureGates:
+    LocalStorageCapacityIsolation: false
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/e2e/localstack.deployment.yaml
+++ b/e2e/localstack.deployment.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localstack
+spec:
+  selector:
+    matchLabels:
+      app: localstack
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: localstack
+    spec:
+      containers:
+      - name: localstack
+        image: localstack/localstack:0.10.5
+        resources:
+          limits:
+            cpu: 300m
+            memory: 500Mi
+        livenessProbe:
+          tcpSocket:
+            port: 4100
+          initialDelaySeconds: 30
+          periodSeconds: 15
+        readinessProbe:
+          tcpSocket:
+            port: 4100
+          initialDelaySeconds: 30
+          periodSeconds: 15
+        ports:
+        - containerPort: 4100
+          name: ssm
+        - containerPort: 4101
+          name: secretsmanager
+        - containerPort: 4102
+          name: sts
+        - containerPort: 32000
+          name: ui
+        env:
+          - name: SERVICES
+            value: "ssm:4100,secretsmanager:4101,sts:4102"
+          - name: PORT_WEB_UI
+            value: "32000"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ssm
+spec:
+  # selector tells Kubernetes what Deployment this Service
+  # belongs to
+  selector:
+    app: localstack
+  ports:
+  - port: 80
+    targetPort: ssm
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: secretsmanager
+spec:
+  # selector tells Kubernetes what Deployment this Service
+  # belongs to
+  selector:
+    app: localstack
+  ports:
+  - port: 80
+    targetPort: secretsmanager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sts
+spec:
+  # selector tells Kubernetes what Deployment this Service
+  # belongs to
+  selector:
+    app: localstack
+  ports:
+  - port: 80
+    targetPort: sts
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack
+spec:
+  # selector tells Kubernetes what Deployment this Service
+  # belongs to
+  type: NodePort
+  selector:
+    app: localstack
+  ports:
+  - nodePort: 32000
+    port: 80
+    targetPort: ui
+
+---

--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+KIND_LOG_LEVEL="info"
+
+if ! [ -z "$DEBUG" ]; then
+	set -x
+  KIND_LOG_LEVEL="debug"
+fi
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RED='\e[35m'
+NC='\e[0m'
+BGREEN='\e[32m'
+
+K8S_VERSION=${K8S_VERSION:-v1.15.3}
+KIND_CLUSTER_NAME="external-secrets-dev"
+REGISTRY=external-secrets
+
+kind --version || $(echo -e "${RED}Please install kind before running e2e tests${NC}";exit 1)
+echo -e "${BGREEN}[dev-env] creating Kubernetes cluster with kind${NC}"
+
+kind create cluster \
+  --loglevel=${KIND_LOG_LEVEL} \
+  --name ${KIND_CLUSTER_NAME} \
+  --config ${DIR}/kind.yaml \
+  --image "kindest/node:${K8S_VERSION}"
+
+export KUBECONFIG="$(kind get kubeconfig-path --name="${KIND_CLUSTER_NAME}")"
+
+echo -e "${BGREEN}building external-secrets images${NC}"
+docker build -t external-secrets:test -f $DIR/../Dockerfile $DIR/../
+docker build -t external-secrets-e2e:test -f $DIR/Dockerfile $DIR/../
+kind load docker-image --name="${KIND_CLUSTER_NAME}" external-secrets-e2e:test
+kind load docker-image --name="${KIND_CLUSTER_NAME}" external-secrets:test
+
+function cleanup {
+  set +e
+  kubectl delete pod e2e 2>/dev/null
+  kubectl delete crd/externalsecrets.kubernetes-client.io 2>/dev/null
+  kubectl delete -f ${DIR}/localstack.deployment.yaml 2>/dev/null
+  kind delete cluster \
+    --loglevel=${KIND_LOG_LEVEL} \
+    --name ${KIND_CLUSTER_NAME}
+
+}
+trap cleanup EXIT
+
+kubectl apply -f ${DIR}/localstack.deployment.yaml
+
+helm template $DIR/../charts/kubernetes-external-secrets \
+  --name e2e \
+  --set image.repository=external-secrets \
+  --set image.tag=test \
+  --set env.LOG_LEVEL=debug \
+  --set env.LOCALSTACK=true \
+  --set env.LOCALSTACK_SSM_URL=http://ssm \
+  --set env.LOCALSTACK_SM_URL=http://secretsmanager \
+  --set env.AWS_ACCESS_KEY_ID=foobar \
+  --set env.AWS_SECRET_ACCESS_KEY=foobar \
+  --set env.AWS_DEFAULT_REGION=us-east-1 \
+  --set env.AWS_REGION=us-east-1 \
+  --set env.POLLER_INTERVAL_MILLISECONDS=1000 \
+  --set env.LOCALSTACK_STS_URL=http://sts | kubectl apply -f -
+
+echo -e "${BGREEN}Granting permissions to external-secrets e2e service account...${NC}"
+kubectl create serviceaccount external-secrets-e2e || true
+kubectl create clusterrolebinding permissive-binding \
+  --clusterrole=cluster-admin \
+  --user=admin \
+  --user=kubelet \
+  --serviceaccount=default:external-secrets-e2e || true
+
+until kubectl get secret | grep -q ^external-secrets-e2e-token; do \
+  echo -e "waiting for api token"; \
+  sleep 3; \
+done
+
+echo -e "${BGREEN}Starting external-secrets e2e tests...${NC}"
+
+kubectl rollout status deploy/localstack
+kubectl rollout status deploy/e2e-kubernetes-external-secrets
+
+kubectl run \
+  --attach \
+  --restart=Never \
+  --env="LOCALSTACK=true" \
+  --env="LOCALSTACK_SSM_URL=http://ssm" \
+  --env="LOCALSTACK_SM_URL=http://secretsmanager" \
+  --env="AWS_ACCESS_KEY_ID=foobar" \
+  --env="AWS_SECRET_ACCESS_KEY=foobar" \
+  --env="AWS_DEFAULT_REGION=us-east-1" \
+  --env="AWS_REGION=us-east-1" \
+  --env="LOCALSTACK_STS_URL=http://sts" \
+  --generator=run-pod/v1 \
+  --overrides='{ "apiVersion": "v1", "spec":{"serviceAccountName": "external-secrets-e2e"}}' \
+  e2e --image=external-secrets-e2e:test

--- a/e2e/tests/crd.test.js
+++ b/e2e/tests/crd.test.js
@@ -1,0 +1,48 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+
+const {
+  kubeClient,
+  customResourceManifest
+} = require('../../config')
+
+const {
+  uuid
+} = require('./framework.js')
+
+describe('CRD', () => {
+  it('should register the CRD on startup', async () => {
+    const res = await kubeClient
+      .apis['apiextensions.k8s.io']
+      .v1beta1
+      .customresourcedefinitions(customResourceManifest.metadata.name)
+      .get()
+    expect(res).to.not.equal(undefined)
+    expect(res.statusCode).to.equal(200)
+  })
+
+  it('should reject invalid ExternalSecret manifests', async () => {
+    kubeClient
+      .apis[customResourceManifest.spec.group]
+      .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+      .post({ body: {
+        apiVersion: 'kubernetes-client.io/v1',
+        kind: 'ExternalSecret',
+        metadata: {
+          name: `e2e-test-validation-${uuid}`
+        },
+        secretDescriptor: {
+          backendType: 'systemManager',
+          data: [
+            {
+              key: `/e2e/${uuid}/name`,
+              name: 'name'
+            }
+          ]
+        }
+      } })
+      .catch(err => expect(err).to.be.an('error'))
+  })
+})

--- a/e2e/tests/framework.js
+++ b/e2e/tests/framework.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const {
+  kubeClient
+} = require('../../config')
+
+/**
+ * "delays" the async execution
+ * @param {Number} ms - number of milliseconds to wait
+ */
+async function delay (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * generate a uuid for this e2e run
+ * taken from https://gist.github.com/6174/6062387
+ */
+const uuid = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)
+
+/**
+ * wait for a secret to appear in a given namespace
+ * this function polls the apiserver for updates in 100ms intervals (max 3s)
+ * @param {String} ns - namespace
+ * @param {String} name - secret name
+ * @return {Secret|undefined}
+ */
+const waitForSecret = async (ns, name) => {
+  for (let i = 0; i <= 30; i++) {
+    try {
+      const secret = await kubeClient
+        .api.v1
+        .namespaces(ns)
+        .secrets(name).get()
+      return secret
+    } catch (e) {
+      await delay(100)
+    }
+  }
+}
+
+module.exports = {
+  uuid,
+  delay,
+  waitForSecret
+}

--- a/e2e/tests/secrets-manager.test.js
+++ b/e2e/tests/secrets-manager.test.js
@@ -1,0 +1,200 @@
+/* eslint-env mocha */
+'use strict'
+
+const util = require('util')
+const { expect } = require('chai')
+
+const {
+  kubeClient,
+  customResourceManifest,
+  awsConfig
+} = require('../../config')
+const {
+  waitForSecret,
+  uuid,
+  delay
+} = require('./framework.js')
+
+const secretsmanager = awsConfig.secretsManagerFactory()
+const createSecret = util.promisify(secretsmanager.createSecret).bind(secretsmanager)
+const putSecretValue = util.promisify(secretsmanager.putSecretValue).bind(secretsmanager)
+
+describe('secretsmanager', async () => {
+  it('should pull existing secret from secretsmanager and create a secret with its values', async () => {
+    let result = await createSecret({
+      Name: `e2e/${uuid}/credentials`,
+      SecretString: '{"username":"foo","password":"bar"}'
+    }).catch(err => {
+      expect(err).to.equal(null)
+    })
+
+    result = await kubeClient
+      .apis[customResourceManifest.spec.group]
+      .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+      .post({ body: {
+        apiVersion: 'kubernetes-client.io/v1',
+        kind: 'ExternalSecret',
+        metadata: {
+          name: `e2e-secretmanager-${uuid}`
+        },
+        spec: {
+          backendType: 'secretsManager',
+          data: [
+            {
+              key: `e2e/${uuid}/credentials`,
+              property: 'password',
+              name: 'password'
+            },
+            {
+              key: `e2e/${uuid}/credentials`,
+              property: 'username',
+              name: 'username'
+            }
+          ]
+        }
+      } })
+
+    expect(result).to.not.equal(undefined)
+    expect(result.statusCode).to.equal(201)
+
+    let secret = await waitForSecret('default', `e2e-secretmanager-${uuid}`)
+    expect(secret).to.not.equal(undefined)
+    expect(secret.body.data.username).to.equal('Zm9v')
+    expect(secret.body.data.password).to.equal('YmFy')
+
+    // update the secret value
+    result = await putSecretValue({
+      SecretId: `e2e/${uuid}/credentials`,
+      SecretString: '{"username":"your mom","password":"1234"}'
+    }).catch(err => {
+      expect(err).to.equal(null)
+    })
+    await delay(2000)
+    secret = await waitForSecret('default', `e2e-secretmanager-${uuid}`)
+    expect(secret.body.data.username).to.equal('eW91ciBtb20=')
+    expect(secret.body.data.password).to.equal('MTIzNA==')
+  })
+
+  it('should pull TLS secret from secretsmanager', async () => {
+    let result = await createSecret({
+      Name: `e2e/${uuid}/tls/cert`,
+      SecretString: '{"crt":"foo","key":"bar"}'
+    }).catch(err => {
+      expect(err).to.equal(null)
+    })
+
+    result = await kubeClient
+      .apis[customResourceManifest.spec.group]
+      .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+      .post({ body: {
+        apiVersion: 'kubernetes-client.io/v1',
+        kind: 'ExternalSecret',
+        metadata: {
+          name: `e2e-secretmanager-tls-${uuid}`
+        },
+        spec: {
+          backendType: 'secretsManager',
+          type: 'kubernetes.io/tls',
+          data: [
+            {
+              key: `e2e/${uuid}/tls/cert`,
+              property: 'crt',
+              name: 'tls.crt'
+            },
+            {
+              key: `e2e/${uuid}/tls/cert`,
+              property: 'key',
+              name: 'tls.key'
+            }
+          ]
+        }
+      } })
+
+    expect(result).to.not.equal(undefined)
+    expect(result.statusCode).to.equal(201)
+
+    const secret = await waitForSecret('default', `e2e-secretmanager-tls-${uuid}`)
+    expect(secret).to.not.equal(undefined)
+    expect(secret.body.data['tls.crt']).to.equal('Zm9v')
+    expect(secret.body.data['tls.key']).to.equal('YmFy')
+    expect(secret.body.type).to.equal('kubernetes.io/tls')
+  })
+
+  describe('permitted annotation', async () => {
+    beforeEach(async () => {
+      await kubeClient.api.v1.namespaces('default').patch({
+        body: {
+          metadata: {
+            annotations: {
+              'iam.amazonaws.com/permitted': '^(foo|bar)'
+            }
+          }
+        }
+      })
+    })
+
+    afterEach(async () => {
+      await kubeClient.api.v1.namespaces('default').patch({
+        body: {
+          metadata: {
+            annotations: {
+              'iam.amazonaws.com/permitted': '.*'
+            }
+          }
+        }
+      })
+    })
+
+    it('should not pull from secretsmanager', async () => {
+      let result = await createSecret({
+        Name: `e2e/${uuid}/tls/permitted`,
+        SecretString: '{"crt":"foo","key":"bar"}'
+      }).catch(err => {
+        expect(err).to.equal(null)
+      })
+
+      result = await kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+        .post({ body: {
+          apiVersion: 'kubernetes-client.io/v1',
+          kind: 'ExternalSecret',
+          metadata: {
+            name: `e2e-secretmanager-permitted-tls-${uuid}`
+          },
+          spec: {
+            backendType: 'secretsManager',
+            type: 'kubernetes.io/tls',
+            // this should not be allowed
+            roleArn: 'let-me-be-root',
+            data: [
+              {
+                key: `e2e/${uuid}/tls/permitted`,
+                property: 'crt',
+                name: 'tls.crt'
+              },
+              {
+                key: `e2e/${uuid}/tls/permitted`,
+                property: 'key',
+                name: 'tls.key'
+              }
+            ]
+          }
+        } })
+
+      expect(result).to.not.equal(undefined)
+      expect(result.statusCode).to.equal(201)
+
+      const secret = await waitForSecret('default', `e2e-secretmanager-permitted-tls-${uuid}`)
+      expect(secret).to.equal(undefined)
+
+      result = await kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.namespaces('default')
+        .externalsecrets(`e2e-secretmanager-permitted-tls-${uuid}`)
+        .get()
+      expect(result).to.not.equal(undefined)
+      expect(result.body.status.status).to.contain('namspace does not allow to assume role let-me-be-root')
+    })
+  })
+})

--- a/e2e/tests/setup.test.js
+++ b/e2e/tests/setup.test.js
@@ -1,0 +1,10 @@
+/* eslint-env mocha */
+'use strict'
+
+const {
+  kubeClient
+} = require('../../config')
+
+before(async () => {
+  await kubeClient.loadSpec()
+})

--- a/e2e/tests/ssm.test.js
+++ b/e2e/tests/ssm.test.js
@@ -1,0 +1,124 @@
+/* eslint-env mocha */
+'use strict'
+
+const util = require('util')
+const { expect } = require('chai')
+
+const {
+  kubeClient,
+  customResourceManifest,
+  awsConfig
+} = require('../../config')
+const { waitForSecret, uuid } = require('./framework.js')
+
+const ssm = awsConfig.systemManagerFactory()
+const putParameter = util.promisify(ssm.putParameter).bind(ssm)
+
+describe('ssm', async () => {
+  it('should pull existing secret from ssm and create a secret from it', async () => {
+    let result = await putParameter({
+      Name: `/e2e/${uuid}/name`,
+      Type: 'String',
+      Value: 'foo'
+    }).catch(err => {
+      expect(err).to.equal(null)
+    })
+
+    result = await kubeClient
+      .apis[customResourceManifest.spec.group]
+      .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+      .post({ body: {
+        apiVersion: 'kubernetes-client.io/v1',
+        kind: 'ExternalSecret',
+        metadata: {
+          name: `e2e-ssm-${uuid}`
+        },
+        spec: {
+          backendType: 'systemManager',
+          data: [
+            {
+              key: `/e2e/${uuid}/name`,
+              name: 'name'
+            }
+          ]
+        }
+      } })
+
+    expect(result).to.not.equal(undefined)
+    expect(result.statusCode).to.equal(201)
+
+    const secret = await waitForSecret('default', `e2e-ssm-${uuid}`)
+    expect(secret.body.data.name).to.equal('Zm9v')
+  })
+
+  describe('permitted annotation', async () => {
+    beforeEach(async () => {
+      await kubeClient.api.v1.namespaces('default').patch({
+        body: {
+          metadata: {
+            annotations: {
+              'iam.amazonaws.com/permitted': '^(foo|bar)'
+            }
+          }
+        }
+      })
+    })
+
+    afterEach(async () => {
+      await kubeClient.api.v1.namespaces('default').patch({
+        body: {
+          metadata: {
+            annotations: {
+              'iam.amazonaws.com/permitted': '.*'
+            }
+          }
+        }
+      })
+    })
+
+    it('should not pull from ssm', async () => {
+      let result = await putParameter({
+        Name: `/e2e/permitted/${uuid}`,
+        Type: 'String',
+        Value: 'foo'
+      }).catch(err => {
+        expect(err).to.equal(null)
+      })
+
+      result = await kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.namespaces('default')[customResourceManifest.spec.names.plural]
+        .post({ body: {
+          apiVersion: 'kubernetes-client.io/v1',
+          kind: 'ExternalSecret',
+          metadata: {
+            name: `e2e-ssm-permitted-${uuid}`
+          },
+          spec: {
+            backendType: 'systemManager',
+            roleArn: 'let-me-be-root',
+            data: [
+              {
+                key: `/e2e/permitted/${uuid}`,
+                name: 'name'
+              }
+            ]
+          }
+        } })
+
+      expect(result).to.not.equal(undefined)
+      expect(result.statusCode).to.equal(201)
+
+      const secret = await waitForSecret('default', `e2e-ssm-permitted-${uuid}`)
+      expect(secret).to.equal(undefined)
+
+      result = await kubeClient
+        .apis[customResourceManifest.spec.group]
+        .v1.namespaces('default')
+        .externalsecrets(`e2e-ssm-permitted-${uuid}`)
+        .get()
+      expect(result).to.not.equal(undefined)
+      expect(result.body.status.status).to.contain('namspace does not allow to assume role let-me-be-root')
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "release": "standard-version --tag-prefix='' && ./release.sh",
     "start": "./bin/daemon.js",
     "nodemon": "nodemon ./bin/daemon.js",
-    "test": "eslint --ignore-pattern /coverage/ ./ && mocha --recursive lib"
+    "test": "eslint --ignore-pattern /coverage/ ./ && mocha --recursive lib",
+    "test-e2e": "./e2e/run-e2e-suite.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey!
I'd like to add e2e tests to the repository in order to test the full path including helm chart configuration, AWS/Localstack integration and the good path (create ES, read data from SSM, wait for secret to appear). This is a first iteration, we can add more tests later on.

I also added validation to the `custom-resource-manifest.json` (using the new `.spec` field).

Unfortunately, we can't test the STS/assume-role integration - local stack does not seem to support it.