### PR TITLE
Support mounting existing secrets as files

### DIFF
--- a/charts/kubernetes-external-secrets/Chart.yaml
+++ b/charts/kubernetes-external-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-external-secrets
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.1.0
 description: Kubernetes External Secrets CustomResourceDefinition
 keywords:

--- a/charts/kubernetes-external-secrets/Chart.yaml
+++ b/charts/kubernetes-external-secrets/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kubernetes-external-secrets
-version: 2.1.1
+version: 2.1.0
 appVersion: 2.1.0
 description: Kubernetes External Secrets CustomResourceDefinition
 keywords:

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -48,6 +48,14 @@ spec:
                 name: {{ $value.secretKeyRef | quote }}
                 key: {{ $value.key | quote }}
           {{- end }}
+          {{- with .Values.filesFromSecret }}
+          volumeMounts:
+          {{- range $key, $value := . }}
+          - name: {{ $key }}
+            mountPath: {{ $value.mountPath }}
+            readOnly: true
+          {{- end }}
+          {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -63,4 +71,12 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.filesFromSecret }}
+      volumes:
+      {{- range $key, $value := . }}
+      - name: {{ $key }}
+        secret:
+          secretName: {{ $value.secret }}
+      {{- end }}
       {{- end }}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -10,7 +10,7 @@ env:
   METRICS_PORT: 3001
   VAULT_ADDR: http://127.0.0.1:8200
 
-# Create environment variables from exists k8s secrets
+# Create environment variables from existing k8s secrets
 # envVarsFromSecret:
 #  AWS_ACCESS_KEY_ID:
 #    secretKeyRef: aws-credentials
@@ -18,6 +18,12 @@ env:
 #  AWS_SECRET_ACCESS_KEY:
 #    secretKeyRef: aws-credentials
 #    key: key
+
+# Create files from existing k8s secrets
+# filesFromSecret:
+#   examplefile:
+#     secret: secretname
+#     mountPath: /a/mount/point/
 
 rbac:
   # Specifies whether RBAC resources should be created


### PR DESCRIPTION
Hello 👋 
I just realised we need to support mounting a CA file as a secret in this pod to communicate with Vault, which is best done through secrets.
This PR therefore copies the `envVarsFromSecret` construct, but for files.
I also bumped the chart version, but I'm not sure that's the correct way of doing things - please let me know if I need to do it differently!
- Florent