### PR TITLE
Vault: stringify JSON response for compatibility with KV backend

### DIFF
--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -53,7 +53,7 @@ class VaultBackend extends KVBackend {
     this._logger.debug(`reading secret key ${key} from vault`)
     const secretResponse = await this._client.read(key)
 
-    return secretResponse.data.data
+    return JSON.stringify(secretResponse.data.data)
   }
 }
 

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -69,7 +69,7 @@ describe('VaultBackend', () => {
       sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
 
       // ... and expect to get its proper value
-      expect(secretPropertyValue).equals('fakeSecretPropertyValue')
+      expect(secretPropertyValue).equals('"fakeSecretPropertyValue"')
     })
 
     it('returns secret property value after renewing token if a token exists', async () => {
@@ -93,7 +93,7 @@ describe('VaultBackend', () => {
       sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
 
       // ... and expect to get its proper value
-      expect(secretPropertyValue).equals('fakeSecretPropertyValue')
+      expect(secretPropertyValue).equals('"fakeSecretPropertyValue"')
     })
   })
 })


### PR DESCRIPTION
Hello, it's me again 👋 

Due to changes in https://github.com/godaddy/kubernetes-external-secrets/pull/206,
we now need to stringify the response from the backend which currently comes as
an object rather than a JSON string.

Fixes issue such as:

```
{"level":30,"time":1573653228258,"pid":19,"hostname":"external-secrets-8zq4bq","msg":"running poll on the secret example/example","v":1}
{"level":40,"time":1573653228468,"pid":19,"hostname":"external-secrets-8zq4bq","msg":"Failed to JSON.parse value for 'secrets/data/example/credentials', please verify that your secret value is correctly formatted as JSON. To use plain text secret remove the 'property: apiToken'","v":1}
```