### PR TITLE
Vault: add better tests, handle missing values

### DIFF
--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -15,6 +15,13 @@ const logger = pino({
 describe('VaultBackend', () => {
   let clientMock
   let vaultBackend
+  const mountPoint = 'fakeMountPoint'
+  const role = 'fakeRole'
+  const secretKey = 'fakeSecretKey'
+  const secretValue = 'open, sesame'
+  const quotedSecretValue = '"' + secretValue + '"'
+  const quotedSecretValueAsBase64 = Buffer.from(quotedSecretValue).toString('base64')
+  const jwt = 'this-is-a-jwt-token'
 
   beforeEach(() => {
     clientMock = sinon.mock()
@@ -26,15 +33,10 @@ describe('VaultBackend', () => {
   })
 
   describe('_get', () => {
-    const mountPoint = 'fakeMountPoint'
-    const role = 'fakeRole'
-    const secretKey = 'fakeSecretKey'
-    const jwt = 'this-is-a-jwt-token'
-
     beforeEach(() => {
       clientMock.read = sinon.stub().returns({
         data: {
-          data: 'fakeSecretPropertyValue'
+          data: secretValue
         }
       })
       clientMock.tokenRenewSelf = sinon.stub().returns(true)
@@ -60,16 +62,16 @@ describe('VaultBackend', () => {
 
       // First, we log into Vault...
       sinon.assert.calledWith(clientMock.kubernetesLogin, {
-        mount_point: 'fakeMountPoint',
-        role: 'fakeRole',
+        mount_point: mountPoint,
+        role: role,
         jwt: jwt
       })
 
       // ... then we fetch the secret ...
-      sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
+      sinon.assert.calledWith(clientMock.read, secretKey)
 
       // ... and expect to get its proper value
-      expect(secretPropertyValue).equals('"fakeSecretPropertyValue"')
+      expect(secretPropertyValue).equals(quotedSecretValue)
     })
 
     it('returns secret property value after renewing token if a token exists', async () => {
@@ -90,10 +92,49 @@ describe('VaultBackend', () => {
       sinon.assert.calledOnce(clientMock.tokenRenewSelf)
 
       // ... then we fetch the secret ...
-      sinon.assert.calledWith(clientMock.read, 'fakeSecretKey')
+      sinon.assert.calledWith(clientMock.read, secretKey)
 
       // ... and expect to get its proper value
-      expect(secretPropertyValue).equals('"fakeSecretPropertyValue"')
+      expect(secretPropertyValue).equals(quotedSecretValue)
+    })
+  })
+
+  describe('getSecretManifestData', () => {
+    beforeEach(() => {
+      clientMock.read = sinon.stub().returns({ data: { data: secretValue } })
+      clientMock.tokenRenewSelf = sinon.stub().returns(true)
+      clientMock.kubernetesLogin = sinon.stub().returns({ auth: { client_token: '1234' } })
+
+      vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
+
+      clientMock.token = undefined
+    })
+
+    it('logs in and returns secret property value', async () => {
+      const returnedData = await vaultBackend.getSecretManifestData({
+        spec: {
+          backendType: 'vault',
+          vaultRole: role,
+          vaultMountPoint: mountPoint,
+          data: [{
+            key: secretKey,
+            name: secretKey
+          }]
+        }
+      })
+
+      // First, we log into Vault...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, secretKey)
+
+      // ... and expect to get the full proper value
+      expect(returnedData[secretKey]).equals(quotedSecretValueAsBase64)
     })
   })
 })


### PR DESCRIPTION
Following-up from #214 : better tests for Vault!

This tests the actual `vaultBackend.getSecretManifestData` method rather than only the inner `_get` method.

Also added some short-circuits that will fail early if required parameters are missing from the ExternalSecret definition.