### PR TITLE
Add podLabels value in chart

### DIFF
--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `serviceAccount.name`                | Service account to be used.                                  | automatically generated                                 |
 | `serviceAccount.annotations`         | Annotations to be added to service account                   | `nil`                                                   |
 | `podAnnotations`                     | Annotations to be added to pods                              | `{}`                                                    |
+| `podLabels`                          | Additional labels to be added to pods                        | `{}`                                                    |
 | `replicaCount`                       | Number of replicas                                           | `1`                                                     |
 | `nodeSelector`                       | node labels for pod assignment                               | `{}`                                                    |
 | `tolerations`                        | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`                                                    |

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+          {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- end }}
       annotations:
       {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -49,6 +49,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 podAnnotations: {}
+podLabels: {}
 
 securityContext: {}
   # fsGroup: 65534


### PR DESCRIPTION
This feature will allow users to specify additional labels to the pods. This is very useful if you for example would like to group components that interact with a specific provider by label. 

Most likely the commit #ed5b199 is not needed. I allow edits from maintainers, so feel free to delete it's not needed, or I can do it myself.