### PR TITLE
Do not skew binary data

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -108,10 +108,16 @@ class KVBackend extends AbstractBackend {
       }), {})
 
     const encodedEntries = Object.entries(plainValues)
-      .map(([name, plainValue]) => [
-        name,
-        (Buffer.from(`${plainValue}`, 'utf8')).toString('base64')
-      ])
+      .map(([name, plainValue]) => {
+        let bufferValue = plainValue
+        if (!(plainValue instanceof Buffer)) {
+          bufferValue = Buffer.from(`${plainValue}`, 'utf8')
+        }
+        return [
+          name,
+          bufferValue.toString('base64')
+        ]
+      })
 
     return Object.fromEntries(encodedEntries)
   }

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -382,5 +382,25 @@ describe('kv-backend', () => {
         specOptions: { }
       })
     })
+
+    it('do not skew binary data', async () => {
+      kvBackend._fetchDataValues
+        .resolves([{
+          textProperty: 'text',
+          binaryProperty: Buffer.from('test', 'utf-8'),
+          binaryProperty2: Buffer.from([0xEFBFBDEF, 2, 3])
+        }])
+
+      const manifestData = await kvBackend
+        .getSecretManifestData({
+          spec: { }
+        })
+
+      expect(manifestData).deep.equals({
+        textProperty: 'dGV4dA==', // base 64 value of text
+        binaryProperty: 'dGVzdA==', // base 64 value of test
+        binaryProperty2: '7wID' // base 64 value of binary data
+      })
+    })
   })
 })


### PR DESCRIPTION
In some cases when AWS Secret Manage secret has a type `Binary` the value can be corrupted during uploading to Kubernetes.
`.SecretBinary` returns Buffer and it should not be converted.
Should fix https://github.com/godaddy/kubernetes-external-secrets/issues/235

Could you please review this @Flydiverny  @silasbw ?