### PR TITLE
Add support for Istio metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ kubernetes-external-secrets exposes the following metrics over a prometheus endp
 | ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `sync_calls`                              | This metric counts the number of sync calls by backend, secret name and status  | `sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1` |
 
+If you are using Istio you can enable metrics to be gathered automatically by setting the helm value `istio.metrics.enabled` to `true`.
 
 ## Development
 

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -69,6 +69,9 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `tolerations`                        | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`                                                    |
 | `affinity`                           | Affinity for pod assignment                                  | `{}`                                                    |
 | `resources`                          | Pod resource requests & limits                               | `{}`                                                    |
+| `istio.metrics.enabled`                          | Enable Istio metrics                               | `false`                                                    |
+| `istio.metrics.port`                          | Default metrics port                               | `3001`                                                    |
+| `istio.metrics.path`                          | Default metrics path                               | `/metrics`                                                    |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -25,6 +25,11 @@ spec:
       {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
+      {{- if .Values.istio.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/path: {{ .Values.istio.metrics.path | quote }}
+        prometheus.io/port: {{ .Values.istio.metrics.port | quote }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "kubernetes-external-secrets.serviceAccountName" . }}
       containers:
@@ -33,6 +38,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.istio.metrics.enabled }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.istio.metrics.port }}
+              protocol: TCP
+          {{- end }}
           env:
           {{- range $name, $value := .Values.env }}
           {{- if not (empty $value) }}

--- a/charts/kubernetes-external-secrets/templates/service.yaml
+++ b/charts/kubernetes-external-secrets/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.istio.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubernetes-external-secrets.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    helm.sh/chart: {{ include "kubernetes-external-secrets.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  ports:
+    - port: {{ .Values.istio.metrics.port }}
+      targetPort: http
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kubernetes-external-secrets.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -38,6 +38,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+istio:
+  metrics:
+    enabled: false
+    port: 3001
+    path: /metrics
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
Thanks for sharing this! I have this setup with Istio and noticed that gathering metrics was not supported in the helm chart. I added a flag to add support for Istio to scrape these metrics (see: https://istio.io/faq/metrics-and-logs/#prometheus-application-metrics). To enable this, your helm `values.yaml` file should contain:

```
istio:
  metrics:
    enabled: true
```

**NOTE:** I thought this could be accomplished by just adding the annotations to `podAnnotations` value, but was running into some issues when mTLS was configured. In addition to the `podAnnotations` it was also required to add a container port and define a `Service`. Once I added those metrics were able to be collected automatically.