### PR TITLE
fix: stringify json object based secrets

### DIFF
--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -84,7 +84,7 @@ class KVBackend extends AbstractBackend {
 
   /**
    * Convert secret value to buffer
-   * @param {string} plainValue - plain secret value
+   * @param {(string|Buffer|object)} plainValue - plain secret value
    * @returns {Buffer} Buffer containing value
    */
   _toBuffer (plainValue) {

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -83,6 +83,23 @@ class KVBackend extends AbstractBackend {
   }
 
   /**
+   * Convert secret value to buffer
+   * @param {string} plainValue - plain secret value
+   * @returns {Buffer} Buffer containing value
+   */
+  _toBuffer (plainValue) {
+    if (plainValue instanceof Buffer) {
+      return plainValue
+    }
+
+    if (typeof plainValue === 'object') {
+      return Buffer.from(JSON.stringify(plainValue), 'utf-8')
+    }
+
+    return Buffer.from(`${plainValue}`, 'utf8')
+  }
+
+  /**
    * Fetch Kubernetes secret manifest data.
    * @param {ExternalSecretSpec} spec - Kubernetes ExternalSecret spec.
    * @returns {Promise} Promise object representing Kubernetes secret manifest data.
@@ -108,16 +125,10 @@ class KVBackend extends AbstractBackend {
       }), {})
 
     const encodedEntries = Object.entries(plainValues)
-      .map(([name, plainValue]) => {
-        let bufferValue = plainValue
-        if (!(plainValue instanceof Buffer)) {
-          bufferValue = Buffer.from(`${plainValue}`, 'utf8')
-        }
-        return [
-          name,
-          bufferValue.toString('base64')
-        ]
-      })
+      .map(([name, plainValue]) => [
+        name,
+        this._toBuffer(plainValue).toString('base64')
+      ])
 
     return Object.fromEntries(encodedEntries)
   }

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -403,4 +403,31 @@ describe('kv-backend', () => {
       })
     })
   })
+
+  describe('base64 encoding', () => {
+    it('handles json objects', async () => {
+      kvBackend._get = sinon.stub()
+      kvBackend._get
+        .resolves(JSON.stringify({
+          textProperty: 'text',
+          jsonStringProperty: '{ "someKey": { "myText": "text" } }',
+          jsonProperty: { someKey: { myText: 'text' } }
+        }))
+
+      const manifestData = await kvBackend
+        .getSecretManifestData({
+          spec: {
+            dataFrom: ['test-key']
+          }
+        })
+
+      expect(kvBackend._get.calledOnce).to.equal(true)
+
+      expect(manifestData).deep.equals({
+        textProperty: 'dGV4dA==', // base 64 value of text
+        jsonStringProperty: 'eyAic29tZUtleSI6IHsgIm15VGV4dCI6ICJ0ZXh0IiB9IH0=', // base 64 value of: { "someKey": { "myText": "text" } }
+        jsonProperty: 'eyJzb21lS2V5Ijp7Im15VGV4dCI6InRleHQifX0=' // base 64 value of: {"someKey":{"myText":"text"}}
+      })
+    })
+  })
 })


### PR DESCRIPTION
When using an external secret like below where the secret value was formated like json you might expect to get the JSON value in the secret but instead you got "[object  Object]"

```yaml
apiVersion: kubernetes-client.io/v1
kind: ExternalSecret
metadata:
  name: secretsmanager-test
spec:
  backendType: secretsManager
  dataFrom:
    - /development/mma/dockerhub
```

Secret value:
```json
{
  "auths": {
    "https://index.docker.io/v1/": {
      "auth": "bXktc2VjcmV0LWNyZWRlbnRpYWw6bm90LW15LXBhc3N3b3JkCg=="
    }
  }
}
```

Gave a secret like
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: secretmanager-test
data:
  auths: W29iamVjdCBPYmplY3Rd
type: Opaque
```

`W29iamVjdCBPYmplY3Rd` -> `[object Object]`

After this change:

`eyJodHRwczovL2luZGV4LmRvY2tlci5pby92MS8iOnsiYXV0aCI6ImJYa3RjMlZqY21WMExXTnlaV1JsYm5ScFlXdzZibTkwTFcxNUxYQmhjM04zYjNKa0NnPT0ifX0=` -> `{"https://index.docker.io/v1/":{"auth":"bXktc2VjcmV0LWNyZWRlbnRpYWw6bm90LW15LXBhc3N3b3JkCg=="}}`