### PR TITLE
Allow null values from System Manager

### DIFF
--- a/lib/backends/system-manager-backend.js
+++ b/lib/backends/system-manager-backend.js
@@ -45,7 +45,7 @@ class SystemManagerBackend extends KVBackend {
         WithDecryption: true
       })
       .promise()
-    return data.Parameter.Value
+    return (key == data.Parameter.Value) ? null : data.Parameter.Value
   }
 }
 


### PR DESCRIPTION
If value equals name set the value of the variable to null. This allows to have null values from parameter store