### PR TITLE
Fix annotation bugs

### DIFF
--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -21,8 +21,8 @@ spec:
       {{- if .Values.podLabels }}
           {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
-      annotations:
       {{- if .Values.podAnnotations }}
+      annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -33,7 +33,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Specifies annotations for this service account
-  annotations:
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:


### PR DESCRIPTION
Before this change, if you tried providing a ServiceAccount annotation
you will get the following error from Helm:
`coalesce.go:199: warning: destination for annotations is a table. Ignoring non-table value <nil>`

This fixes the default value so this issue doesn't happen.

There is also another fix for the annotations in the deployment so that it's more consistent with other areas. Without this, we generate an empty annotations section in the deployment when no podAnnotations are provided.