### PR TITLE
fix: remove required top level key from vault backend validation

### DIFF
--- a/crd.yaml
+++ b/crd.yaml
@@ -83,7 +83,6 @@ spec:
               required:
                 - vaultRole
                 - vaultMountPoint
-                - key
           anyOf:
             - required:
               - data


### PR DESCRIPTION
Fixes #248