### PR TITLE
docs: Clarify IAM role usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,26 @@ $ helm template -f charts/kubernetes-external-secrets/values.yaml --output-dir .
 
 The generated kubernetes manifests will be in `./output_dir` and can be applied to deploy `kubernetes-external-secrets` to the cluster.
 
-### Use IAM credentials for Secrets Manager access
+### Secrets Manager access
 
-If not running on EKS you will have to use an IAM user (in lieu of a role).
-Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars in the session/pod.
-You can use envVarsFromSecret in the helm chart to create these env vars from existing k8s secrets
+For `kubernetes-external-secrets` to be able to retrieve your secrets it will need access to your secret backend.
+
+#### AWS based backends
+
+Access to AWS secrets backends (SSM & secrets manager) can be granted in various ways:
+
+1. Granting your nodes explicit access to your secrets using the [node instance role](https://docs.aws.amazon.com/eks/latest/userguide/worker_node_IAM_role.html) (easy for experimentation, not recommended)
+
+2. [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+3. Per pod IAM authentication: [kiam](https://github.com/uswitch/kiam) or [kube2iam](https://github.com/jtblin/kube2iam).
+
+4. Directly provide AWS access credentials to the `kubernetes-external-secrets` pod by environmental variables.
+
+##### Using AWS access credentials
+
+Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars in the `kubernetes-external-secrets` session/pod.
+You can use envVarsFromSecret in the helm chart to create these env vars from existing k8s secrets.
 
 Additionally, you can specify a `roleArn` which will be assumed before retrieving the secret.
 You can limit the range of roles which can be assumed by this particular *namespace* by using annotations on the namespace resource. The annotation key is configurable (see above). The annotation value is evaluated as a regular expression and tries to match the `roleArn`.


### PR DESCRIPTION
Clarify that `kubernetes-external-secrets` inherits the IAM role of the node it's running on when situated in AWS, whether its within EKS or otherwise.

Also: thank you for sharing this project, is awesome! :pray: 