### PR TITLE
Add git for dockerignore and fix CVE critical issues on nodejs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ coverage
 Dockerfile
 node_modules
 release.sh
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:12.13.0-alpine
+FROM node:12.15.0-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info
-
-RUN npm install npm@6.4.1 -g
 
 # Setup source directory
 RUN mkdir /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.16.0-alpine
+FROM node:12.16.1-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,12 @@ ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info
 
 # Setup source directory
-RUN mkdir /app
 WORKDIR /app
-COPY package.json package-lock.json /app/
+COPY package*.json ./
 RUN npm ci --production
 
 # Copy app to source directory
-COPY . /app
+COPY . .
 
 USER node
 CMD ["npm", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.15.0-alpine
+FROM node:12.16.0-alpine
 
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
Hello! I changed a few things as follows.

- Add .git in dockerignore so that the image size potentially will be decreased.
- 1 critical and 2 high security issues have been reported for Node.js and 12.15 addressed them.
- npm no longer has to be updated as the base image contains a newer version
- Remove `RUN mkdir` in Dockerfile as WORKDIR does what it does
- other simplyfing Dockerfile format

```
$ docker images
REPOSITORY              TAG              IMAGE ID          CREATED           SIZE
before                  latest           742f1e7b5381      4 seconds ago     195MB
after                   latest           0a20262f7686      35 seconds ago    177MB
```