### PR TITLE
WIP: Add support for intermediate role

### DIFF
--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -39,7 +39,7 @@ module.exports = {
     }
     return new AWS.SSM(opts)
   },
-  assumeRole: (assumeRoleOpts) => {
+  assumeRole: (assumeRoleOpts, stsConfig) => {
     const sts = new AWS.STS(stsConfig)
     return new Promise((resolve, reject) => {
       sts.assumeRole(assumeRoleOpts, (err, res) => {

--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -9,7 +9,7 @@ class SecretsManagerBackend extends KVBackend {
    * @param {Object} client - Client for interacting with Secrets Manager.
    * @param {Object} logger - Logger for logging stuff.
    */
-  constructor ({ clientFactory, assumeRole, logger }) {
+  constructor({ clientFactory, assumeRole, logger }) {
     super({ logger })
     this._client = clientFactory()
     this._clientFactory = clientFactory
@@ -23,17 +23,35 @@ class SecretsManagerBackend extends KVBackend {
    * @param {string} keyOptions.versionStage - Version stage
    * @param {object} specOptions - Options for this external secret, eg role
    * @param {string} specOptions.roleArn - IAM role arn to assume
+   * @param {string} specOptions.intermediateRoleArn - an intermediate IAM role to assume before assuming role to the secret role
    * @returns {Promise} Promise object representing secret property value.
    */
-  async _get ({ key, specOptions: { roleArn }, keyOptions: { versionStage = 'AWSCURRENT' } }) {
+  async _get({ key, specOptions: { intermediateRoleArn, roleArn }, keyOptions: { versionStage = 'AWSCURRENT' } }) {
     this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'}`)
 
+    const intermediateRole = intermediateRoleArn || process.env.INTERMEDIATE_ROLE_ARN || 0
+
     let client = this._client
+    let clientParams = {}
     if (roleArn) {
+      if (intermediateRole) {
+        this._logger.info(`intermediate role set - assuming role to ${intermediateRole}`)
+        const int = await this._assumeRole({
+          RoleArn: intermediateRole,
+          RoleSessionName: 'k8s-external-secrets'
+        })
+        clientParams = {
+          accessKeyId: int.Credentials.AccessKeyId,
+          secretAccessKey: int.Credentials.SecretAccessKey,
+          sessionToken: int.Credentials.SessionToken
+        }
+      } else {
+        clientParams = {}
+      }
       const res = await this._assumeRole({
         RoleArn: roleArn,
         RoleSessionName: 'k8s-external-secrets'
-      })
+      }, clientParams)
       client = this._clientFactory({
         accessKeyId: res.Credentials.AccessKeyId,
         secretAccessKey: res.Credentials.SecretAccessKey,

--- a/lib/backends/system-manager-backend.js
+++ b/lib/backends/system-manager-backend.js
@@ -9,7 +9,7 @@ class SystemManagerBackend extends KVBackend {
    * @param {Object} client - Client for interacting with System Manager.
    * @param {Object} logger - Logger for logging stuff.
    */
-  constructor ({ clientFactory, assumeRole, logger }) {
+  constructor({ clientFactory, assumeRole, logger }) {
     super({ logger })
     this._client = clientFactory()
     this._clientFactory = clientFactory
@@ -24,15 +24,32 @@ class SystemManagerBackend extends KVBackend {
    * @param {string} specOptions.roleArn - IAM role arn to assume
    * @returns {Promise} Promise object representing secret property value.
    */
-  async _get ({ key, specOptions: { roleArn } }) {
+  async _get({ key, specOptions: { intermediateRoleArn, roleArn } }) {
     this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'}`)
 
+    const intermediateRole = intermediateRoleArn || process.env.INTERMEDIATE_ROLE_ARN || 0
+
     let client = this._client
+    let clientParams = {}
     if (roleArn) {
+      if (intermediateRole) {
+        this._logger.info(`intermediate role set - assuming role to ${intermediateRole}`)
+        const int = await this._assumeRole({
+          RoleArn: intermediateRole,
+          RoleSessionName: 'k8s-external-secrets'
+        })
+        clientParams = {
+          accessKeyId: int.Credentials.AccessKeyId,
+          secretAccessKey: int.Credentials.SecretAccessKey,
+          sessionToken: int.Credentials.SessionToken
+        }
+      } else {
+        clientParams = {}
+      }
       const res = await this._assumeRole({
         RoleArn: roleArn,
         RoleSessionName: 'k8s-external-secrets'
-      })
+      }, clientParams)
       client = this._clientFactory({
         accessKeyId: res.Credentials.AccessKeyId,
         secretAccessKey: res.Credentials.SecretAccessKey,


### PR DESCRIPTION
I've added a WIP tag to this MR because I need feedback about the best way of implementing this.

We've implemented KIAM in a way that means our kiam nodes (our masters, in this case) assume role to an intermediate role. We want to have this capability in kubernetes-external-secrets, so I've done a very hacked together job of supporting this in two ways with this MR for secretsmanager - either via an additional spec field or an environment var.

I'm looking for feedback on a better way of implementing this so that it follows your needs and is testable. I'm a very very novice javascript developer but willing to take feedback and criticism where it's needed. If this isn't functionality you need to support. but looking at #280 seems to indicate other people might have run into this.

Happy to get any feedback 