### PR TITLE
Update vault-backend.js

### DIFF
--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -56,7 +56,7 @@ class VaultBackend extends KVBackend {
     from the Vault in JSON format we need to parse it to have actual data rather than
     having a double quotes added data content.*/
     secretValue = JSON.stringify(secretResponse.data.data)
-    return JSON.secretdataVaule(secretVaule)
+    return JSON.parse(secretVaule)
   }
 }
 

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -52,8 +52,11 @@ class VaultBackend extends KVBackend {
 
     this._logger.debug(`reading secret key ${key} from vault`)
     const secretResponse = await this._client.read(key)
-
-    return JSON.stringify(secretResponse.data.data)
+    /**As the stringify adds addtional double quotes to the data that is retrieved 
+    from the Vault in JSON format we need to parse it to have actual data rather than
+    having a double quotes added data content.*/
+    secretValue = JSON.stringify(secretResponse.data.data)
+    return JSON.secretdataVaule(secretVaule)
   }
 }
 


### PR DESCRIPTION
As the stringify adds addtional double quotes to the data that is retrieved from the Vault in JSON format we need to parse it to have actual data rather than having a double quotes added data content