### PR TITLE
Remove newlines, spaces, and tabs from status string

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -161,6 +161,9 @@ class Poller {
   }
 
   async _updateStatus (status) {
+    // Remove newlines, spaces, and tabs from status string
+    status = status.replace(/(\r\n|\n|\r| (?= ))/gm, '').replace(/\t/g, ' ')
+
     try {
       this._logger.debug(`updating status for ${this._namespace}/${this._name} to: ${status}`)
       await this._status.put({

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -405,6 +405,15 @@ describe('Poller', () => {
       expect(error).to.not.equal(undefined)
       expect(error.message).equals('Not Found')
     })
+
+    it('handles odd whitespace and newlines in status', async () => {
+      const poller = pollerFactory()
+
+      await poller._updateStatus('\n\n\nLots      of spaces\n\n\n').then(() => {
+        const statusMessage = externalSecretsApiMock.status.put.getCall(0).args[0].body.status.status
+        expect(statusMessage).to.equal('Lots of spaces')
+      })
+    })
   })
 
   describe('_scheduleNextPoll', () => {


### PR DESCRIPTION
Vault error messages seem to have newlines and tabs which don't look great in k8s status message. This PR cleans up the status string before sending to k8s.

Before:
<img width="554" alt="Screen Shot 2020-03-24 at 9 22 13 PM" src="https://user-images.githubusercontent.com/5752872/77492292-95d01780-6e16-11ea-93c0-3f770c7a1642.png">

After:
<img width="735" alt="Screen Shot 2020-03-24 at 9 29 21 PM" src="https://user-images.githubusercontent.com/5752872/77492298-9a94cb80-6e16-11ea-8dba-97902f1127d0.png">