### PR TITLE
fix(azure-registry): handle binary files

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ spec:
   data:
     - key: hello-service/credentials
       name: password
-      isBinary: "true"
+      isBinary: true
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,24 @@ spec:
       property: value
 ```
 
+Due to the way Azure handles binary files, you need to explicitly let the ExternalSecret know that the secret is binary.
+You can do that with the `isBinary` field on the key. This is necessary for certificates and other secret binary files.
+
+```yml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: hello-keyvault-service
+spec:
+  backendType: azureKeyVault
+  keyVaultName: hello-world
+  data:
+    - key: hello-service/credentials
+      name: password
+      isBinary: "true"
+```
+
+
 ## Metrics
 
 kubernetes-external-secrets exposes the following metrics over a prometheus endpoint:

--- a/crd.yaml
+++ b/crd.yaml
@@ -70,7 +70,10 @@ spec:
                   property:
                     description: Property to extract if secret in backend is a JSON object
                   isBinary:
-                    description: Handle the secret as a binary file, used in Azure KeyVault to avoid base64 encoding a binary file as they are already base64 encoded.
+                    description: >-
+                      You must set this to true if configuring an item for a binary file stored in Azure KeyVault.
+                      Azure automatically base64 encodes binary files and setting this to true ensures External Secrets
+                      does not base64 encode the base64 encoded binary files.
                     type: boolean
                 required:
                   - name

--- a/crd.yaml
+++ b/crd.yaml
@@ -69,6 +69,9 @@ spec:
                     type: string
                   property:
                     description: Property to extract if secret in backend is a JSON object
+                  isBinary:
+                    description: Handle the secret as a binary file, used in Azure KeyVault to avoid base64 encoding a binary file as they are already base64 encoded.
+                    type: boolean
                 required:
                   - name
                   - key

--- a/lib/backends/azure-keyvault-backend.js
+++ b/lib/backends/azure-keyvault-backend.js
@@ -26,13 +26,18 @@ class AzureKeyVaultBackend extends KVBackend {
    * Get secret property value from Azure Key Vault.
    * @param {string} key - Key used to store secret property value in Azure Key Vault.
    * @param {string} specOptions.keyVaultName - Name of the azure key vault
+   * @param {string} keyOptions.isBinary - Does the secret contain a binary? Set to "true" to handle as binary. Does not work with "property"
    * @returns {Promise} Promise object representing secret property value.
    */
 
-  async _get ({ key, specOptions: { keyVaultName } }) {
+  async _get ({ key, keyOptions, specOptions: { keyVaultName } }) {
     const client = this._keyvaultClient({ keyVaultName })
     this._logger.info(`fetching secret ${key} from Azure KeyVault ${keyVaultName}`)
     const secret = await client.getSecret(key)
+    // Handle binary files, since the Azure client does not
+    if (keyOptions && keyOptions.isBinary && keyOptions.isBinary.toLowerCase() === 'true') {
+      return Buffer.from(secret.value, 'base64')
+    }
     return JSON.stringify(secret)
   }
 }

--- a/lib/backends/azure-keyvault-backend.js
+++ b/lib/backends/azure-keyvault-backend.js
@@ -35,7 +35,7 @@ class AzureKeyVaultBackend extends KVBackend {
     this._logger.info(`fetching secret ${key} from Azure KeyVault ${keyVaultName}`)
     const secret = await client.getSecret(key)
     // Handle binary files, since the Azure client does not
-    if (keyOptions && keyOptions.isBinary && keyOptions.isBinary.toLowerCase() === 'true') {
+    if (keyOptions && keyOptions.isBinary) {
       return Buffer.from(secret.value, 'base64')
     }
     return JSON.stringify(secret)


### PR DESCRIPTION
Hi!

# The issue
We had an issue with fetching certificates from the Azure KeyVaults.
Because the certificate were binary files, the Azure KeyVault would base64 encode it, however the @azure/keyvault-secrets library gives no notice or way to detect that the secret is base64 encoded.

Then kubernetes-external-secrets would base64 encode it again, so the binary files were base64 encoded twice, which meant that we had to alter our application to base64 decode the certificates before we could use them.

# This change
Here we add a new `keyOptions` field `isBinary` so that you can explicitly specify that the Azure KeyVault secret is a binary and that no base64 encoding should happen.

Notice that the `isBinary` field does not work together with the `property` field, as the `property` field does JSON-decode and that would definetly not work on a Buffer.