### PR TITLE
Update readme. Azure docs out of order

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,23 @@ spec:
       property: value
 ```
 
+Due to the way Azure handles binary files, you need to explicitly let the ExternalSecret know that the secret is binary.
+You can do that with the `isBinary` field on the key. This is necessary for certificates and other secret binary files.
+
+```yml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: hello-keyvault-service
+spec:
+  backendType: azureKeyVault
+  keyVaultName: hello-world
+  data:
+    - key: hello-service/credentials
+      name: password
+      isBinary: true
+```
+
 ### GCP Secret Manager
 
 kubernetes-external-secrets supports fetching secrets from [GCP Secret Manager](https://cloud.google.com/solutions/secrets-management)
@@ -409,24 +426,6 @@ spec:
       name: password
       property: value
 ```
-
-Due to the way Azure handles binary files, you need to explicitly let the ExternalSecret know that the secret is binary.
-You can do that with the `isBinary` field on the key. This is necessary for certificates and other secret binary files.
-
-```yml
-apiVersion: kubernetes-client.io/v1
-kind: ExternalSecret
-metadata:
-  name: hello-keyvault-service
-spec:
-  backendType: azureKeyVault
-  keyVaultName: hello-world
-  data:
-    - key: hello-service/credentials
-      name: password
-      isBinary: true
-```
-
 
 ## Metrics
 


### PR DESCRIPTION
This block for azure binary files is not under the azure headline. It was bothering me