### PR TITLE
Enable use of AWS STS regional endpoints

### DIFF
--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -9,7 +9,10 @@ const localstack = process.env.LOCALSTACK || 0
 
 let secretsManagerConfig = {}
 let systemManagerConfig = {}
-let stsConfig = {}
+let stsConfig = {
+  region: process.env.AWS_REGION || 'us-west-2',
+  stsRegionalEndpoints: process.env.AWS_STS_ENDPOINT_TYPE || 'regional'
+}
 
 if (localstack) {
   secretsManagerConfig = {


### PR DESCRIPTION
The default STS configuration uses the legacy global endpoint, which does not work from private VPCs accessing STS via VPC Endpoints.  This change adds the `region` and `stsRegionalEndpoints` values to the `stsConfig` object used to construct the STS client.  It defaults to "regional" as the value of `stsRegionalEndpoints` but honors the `AWS_STS_ENDPOINT_TYPE` environment variable for users who prefer/require the use of "legacy" endpoints.