### PR TITLE
Add last_state metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ kubernetes-external-secrets exposes the following metrics over a prometheus endp
 | Metric                                    | Description                                                                     | Example                                                                       |
 | ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `sync_calls`                              | This metric counts the number of sync calls by backend, secret name and status  | `sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1` |
+| `last_state`                              | A value of -1 or 1 where -1 means the last sync_call was an error and 1 means the last sync_call was a success  | `last_state{name="foo",namespace="example",backend="foo"} 1` |
 
 
 ## Development

--- a/lib/metrics-server.test.js
+++ b/lib/metrics-server.test.js
@@ -57,5 +57,7 @@ describe('MetricsServer', () => {
 
     expect(res.text).to.have.string('sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1')
     expect(res.text).to.have.string('sync_calls{name="bar",namespace="example",backend="foo",status="failed"} 1')
+    expect(res.text).to.have.string('last_state{name="foo",namespace="example",backend="foo"} 1')
+    expect(res.text).to.have.string('last_state{name="bar",namespace="example",backend="foo"} -1')
   })
 })

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -15,6 +15,12 @@ class Metrics {
       labelNames: ['name', 'namespace', 'backend', 'status'],
       registers: [registry]
     })
+    this._lastState = new Prometheus.Gauge({
+      name: 'last_state',
+      help: 'Value -1 if the last sync was a failure, 1 otherwise.',
+      labelNames: ['name', 'namespace', 'backend'],
+      registers: [registry]
+    })
   }
 
   /**
@@ -31,6 +37,19 @@ class Metrics {
       backend,
       status
     })
+    if (status === 'success') {
+      this._lastState.set({
+        name,
+        namespace,
+        backend
+      }, 1)
+    } else {
+      this._lastState.set({
+        name,
+        namespace,
+        backend
+      }, -1)
+    }
   }
 }
 


### PR DESCRIPTION
It is a bit difficult to alert on sync_calls since they trigger into an error state and may stay there.
This adds the gauge last_state.  With last_state, people can easily alert on a value < 0 to indicate failure.