### PR TITLE
Improve out-of-the-box compatibility with clusters running PodSecurityPolicy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,6 @@ RUN npm ci --production
 # Copy app to source directory
 COPY . .
 
-USER node
+# Change back to the "node" user; using its UID for PodSecurityPolicy "non-root" compatibility
+USER 1000
 CMD ["npm", "start"]

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -41,41 +41,41 @@ helm delete my-release
 
 The following table lists the configurable parameters of the `kubernetes-external-secrets` chart and their default values.
 
-| Parameter                            | Description                                                  | Default                                                 |
-| ------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------- |
-| `env.AWS_REGION`                     | Set AWS_REGION in Deployment Pod                             | `us-west-2`                                             |
-| `env.LOG_LEVEL`                           | Set the application log level                                | `info`                                                  |
-| `env.METRICS_PORT`                        | Specify the port for the prometheus metrics server           | `3001`                                                  |
-| `env.ROLE_PERMITTED_ANNOTATION`           | Specify the annotation key where to lookup the role arn permission boundaries | `iam.amazonaws.com/permitted`          |
-| `env.POLLER_INTERVAL_MILLISECONDS`   | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod           | `10000`                                                 |
-| `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault               | `http://127.0.0.1:8200                                  |
-| `env.DISABLE_POLLING`                          | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling               | `nil`                                  |
-| `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod      |                                                         |
-| `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod  |                                                         |
-| `envVarsFromSecret.AZURE_TENANT_ID`     | Set AZURE_TENANT_ID (from a secret) in Deployment Pod      |                                                         |
-| `envVarsFromSecret.AZURE_CLIENT_ID` | Set AZURE_CLIENT_ID (from a secret) in Deployment Pod  |                                                         |
-| `envVarsFromSecret.AZURE_CLIENT_SECRET` | Set AZURE_CLIENT_SECRET (from a secret) in Deployment Pod  |                                                         |
-| `image.repository`                   | kubernetes-external-secrets Image name                       | `godaddy/kubernetes-external-secrets`                   |
-| `image.tag`                          | kubernetes-external-secrets Image tag | `3.2.0`                                                 |
-| `image.pullPolicy`                   | Image pull policy                                            | `IfNotPresent`                                          |
-| `nameOverride`                   | Override the name of app                                            | `nil`                                          |
-| `fullnameOverride`                   | Override the full name of app                                            | `nil`                                          |
-| `rbac.create`                        | Create & use RBAC resources                                  | `true`                                                  |
-| `securityContext.fsGroup`            | Security context for the container                           | `{}`                                                    |
-| `serviceAccount.create`              | Whether a new service account name should be created.        | `true`                                                  |
-| `serviceAccount.name`                | Service account to be used.                                  | automatically generated                                 |
-| `serviceAccount.annotations`         | Annotations to be added to service account                   | `nil`                                                   |
-| `podAnnotations`                     | Annotations to be added to pods                              | `{}`                                                    |
-| `podLabels`                          | Additional labels to be added to pods                        | `{}`                                                    |
-| `replicaCount`                       | Number of replicas                                           | `1`                                                     |
-| `nodeSelector`                       | node labels for pod assignment                               | `{}`                                                    |
-| `tolerations`                        | List of node taints to tolerate (requires Kubernetes >= 1.6) | `[]`                                                    |
-| `affinity`                           | Affinity for pod assignment                                  | `{}`                                                    |
-| `resources`                          | Pod resource requests & limits                               | `{}`                                                    |
-| `imagePullSecrets`                   | Reference to one or more secrets to be used when pulling images              | `[]`                                                    |
-| `serviceMonitor.enabled`             | Enable the creation of a serviceMonitor object for the Prometheus operator              | `false`                                    |
-| `serviceMonitor.interval`            | The interval the Prometheus endpoint is scraped              | `30s`                                    |
-| `serviceMonitor.namespace`           | The namespace where the serviceMonitor object has to be created           | `nil`                                    |
+| Parameter                                 | Description                                                                                                                       | Default                               |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `env.AWS_REGION`                          | Set AWS_REGION in Deployment Pod                                                                                                  | `us-west-2`                           |
+| `env.LOG_LEVEL`                           | Set the application log level                                                                                                     | `info`                                |
+| `env.METRICS_PORT`                        | Specify the port for the prometheus metrics server                                                                                | `3001`                                |
+| `env.ROLE_PERMITTED_ANNOTATION`           | Specify the annotation key where to lookup the role arn permission boundaries                                                     | `iam.amazonaws.com/permitted`         |
+| `env.POLLER_INTERVAL_MILLISECONDS`        | Set POLLER_INTERVAL_MILLISECONDS in Deployment Pod                                                                                | `10000`                               |
+| `env.VAULT_ADDR`                          | Endpoint for the Vault backend, if using Vault                                                                                    | `http://127.0.0.1:8200                |
+| `env.DISABLE_POLLING`                     | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling | `nil`                                 |
+| `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod                                                                           |                                       |
+| `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod                                                                       |                                       |
+| `envVarsFromSecret.AZURE_TENANT_ID`       | Set AZURE_TENANT_ID (from a secret) in Deployment Pod                                                                             |                                       |
+| `envVarsFromSecret.AZURE_CLIENT_ID`       | Set AZURE_CLIENT_ID (from a secret) in Deployment Pod                                                                             |                                       |
+| `envVarsFromSecret.AZURE_CLIENT_SECRET`   | Set AZURE_CLIENT_SECRET (from a secret) in Deployment Pod                                                                         |                                       |
+| `image.repository`                        | kubernetes-external-secrets Image name                                                                                            | `godaddy/kubernetes-external-secrets` |
+| `image.tag`                               | kubernetes-external-secrets Image tag                                                                                             | `3.2.0`                               |
+| `image.pullPolicy`                        | Image pull policy                                                                                                                 | `IfNotPresent`                        |
+| `nameOverride`                            | Override the name of app                                                                                                          | `nil`                                 |
+| `fullnameOverride`                        | Override the full name of app                                                                                                     | `nil`                                 |
+| `rbac.create`                             | Create & use RBAC resources                                                                                                       | `true`                                |
+| `securityContext`                         | Pod-wide security context                                                                                                         | `{ runAsNonRoot: true }`              |
+| `serviceAccount.create`                   | Whether a new service account name should be created.                                                                             | `true`                                |
+| `serviceAccount.name`                     | Service account to be used.                                                                                                       | automatically generated               |
+| `serviceAccount.annotations`              | Annotations to be added to service account                                                                                        | `nil`                                 |
+| `podAnnotations`                          | Annotations to be added to pods                                                                                                   | `{}`                                  |
+| `podLabels`                               | Additional labels to be added to pods                                                                                             | `{}`                                  |
+| `replicaCount`                            | Number of replicas                                                                                                                | `1`                                   |
+| `nodeSelector`                            | node labels for pod assignment                                                                                                    | `{}`                                  |
+| `tolerations`                             | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                      | `[]`                                  |
+| `affinity`                                | Affinity for pod assignment                                                                                                       | `{}`                                  |
+| `resources`                               | Pod resource requests & limits                                                                                                    | `{}`                                  |
+| `imagePullSecrets`                        | Reference to one or more secrets to be used when pulling images                                                                   | `[]`                                  |
+| `serviceMonitor.enabled`                  | Enable the creation of a serviceMonitor object for the Prometheus operator                                                        | `false`                               |
+| `serviceMonitor.interval`                 | The interval the Prometheus endpoint is scraped                                                                                   | `30s`                                 |
+| `serviceMonitor.namespace`                | The namespace where the serviceMonitor object has to be created                                                                   | `nil`                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -62,7 +62,9 @@ fullnameOverride: ""
 podAnnotations: {}
 podLabels: {}
 
-securityContext: {}
+securityContext:
+  runAsNonRoot: true
+  # Required for use of IRSA, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html
   # fsGroup: 65534
 
 resources: {}


### PR DESCRIPTION
**Background**

We run our EKS clusters with locked-down `PodSecurityPolicy` by default; that is we drop all privileges and change the default EKS policy to one that is essentially unprivileged.

`kubernetes-external-secrets` does not appear to require any particular privileges that are from the set.

This makes two changes to allow the chart/image to work out of the box without configuration on the user side.

1. changes the `Dockerfile` to indicate the user as `uid` 1000 rather than `node`, which is required to indicate K8S that it's not running as root (when running under Docker, at least) - [consistent with the base node images](https://github.com/nodejs/docker-node/blob/master/12/alpine3.11/Dockerfile#L6)
    
    Minimal workaround on `3.2.0` without the change in this PR is a `values.yaml` override of
    ```
    securityContext:
      runAsUser: 1000
    ```
1. changes the defaults to include a `securityContext` that specifies the non root requirement.

This second change is a little more debatable and I am interested in feedback however it seems a sensible idea to give an indication to chart users the actual requirements of `kubernetes-external-secrets` pods so they can craft custom policies if necessary; and understand any possible additional attack surface required for running a security-sensitive tool like this in their cluster (which I would argue is minimal given the pod requirements).

A possible follow-up step would be to allow to specify the **container** `securityContext` rather than just the pod-level; which would allow us to specify
```
securityContext:
  privileged: false
  allowPrivilegeEscalation: false
   capabilities:
    drop: ["ALL"]
  readOnlyRootFilesystem: true
```

This has been tested to work fine and automatically select a relatively unprivileged "secure-by-default" PSP like the below
```yaml
apiVersion: extensions/v1beta1
kind: PodSecurityPolicy
metadata:
  name: unprivileged
spec:
  allowPrivilegeEscalation: false
  defaultAllowPrivilegeEscalation: false
  fsGroup:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  readOnlyRootFilesystem: true
  requiredDropCapabilities:
  - ALL
  runAsUser:
    rule: MustRunAsNonRoot
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    ranges:
    - max: 65535
      min: 1
    rule: MustRunAs
  volumes:
  - configMap
  - emptyDir
  - projected
  - secret
```