### PR TITLE
fix(vault): follow all redirects to support vault HA

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -52,7 +52,15 @@ const systemManagerBackend = new SystemManagerBackend({
   assumeRole: awsConfig.assumeRole,
   logger
 })
-const vaultClient = vault({ apiVersion: 'v1', endpoint: envConfig.vaultEndpoint })
+const vaultClient = vault({
+  apiVersion: 'v1',
+  endpoint: envConfig.vaultEndpoint,
+  requestOptions: {
+    // When running vault in HA mode, you must follow redirects on PUT/POST/DELETE
+    // See: https://github.com/kr1sp1n/node-vault/issues/23
+    followAllRedirects: true
+  }
+})
 const vaultBackend = new VaultBackend({ client: vaultClient, logger })
 const azureKeyVaultBackend = new AzureKeyVaultBackend({
   credential: azureConfig.azureKeyVault(),


### PR DESCRIPTION
In HA mode, Vault may return 307 redirect responses. This sets `followAllRedirects: true` so that VaultClient follows these 307 redirects for non-GET requests (kubernetesLogin, refreshTokenSelf).

See: https://github.com/kr1sp1n/node-vault/issues/23