### PR TITLE
feat: allow permitted-key-name to be provided as list

### DIFF
--- a/lib/poller.js
+++ b/lib/poller.js
@@ -209,7 +209,12 @@ class Poller {
     // Testing data property
     if (namingConvention && externalData) {
       externalData.forEach((secretProperty, index) => {
-        const reNaming = new RegExp(namingConvention)
+        let reNaming = new RegExp()
+        if (Array.isArray(namingConvention)) {
+          reNaming = new RegExp(namingConvention.join('|'))
+        } else {
+          reNaming = new RegExp(namingConvention)
+        }
         if (!reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
@@ -223,8 +228,13 @@ class Poller {
     // Testing DataFrom property
     const externalDataFrom = descriptor.dataFrom
     if (namingConvention && externalDataFrom) {
+      let reNaming = new RegExp()
       externalDataFrom.forEach((secretProperty, index) => {
-        const reNaming = new RegExp(namingConvention)
+        if (Array.isArray(namingConvention)) {
+          reNaming = new RegExp(namingConvention.join('|'))
+        } else {
+          reNaming = new RegExp(namingConvention)
+        }
         if (!reNaming.test(secretProperty)) {
           allowed = false
           reason = `key name ${secretProperty} does not match naming convention ${namingConvention}`

--- a/lib/poller.js
+++ b/lib/poller.js
@@ -205,16 +205,16 @@ class Poller {
 
     const externalData = descriptor.data || descriptor.properties
     const namingConvention = namespace.metadata.annotations[this._namingPermittedAnnotation]
+    let reNaming = new RegExp()
+    if (Array.isArray(namingConvention)) {
+      reNaming = new RegExp(namingConvention.join('|'))
+    } else {
+      reNaming = new RegExp(namingConvention)
+    }
 
     // Testing data property
     if (namingConvention && externalData) {
       externalData.forEach((secretProperty, index) => {
-        let reNaming = new RegExp()
-        if (Array.isArray(namingConvention)) {
-          reNaming = new RegExp(namingConvention.join('|'))
-        } else {
-          reNaming = new RegExp(namingConvention)
-        }
         if (!reNaming.test(secretProperty.key)) {
           allowed = false
           reason = `key name ${secretProperty.key} does not match naming convention ${namingConvention}`
@@ -228,13 +228,7 @@ class Poller {
     // Testing DataFrom property
     const externalDataFrom = descriptor.dataFrom
     if (namingConvention && externalDataFrom) {
-      let reNaming = new RegExp()
       externalDataFrom.forEach((secretProperty, index) => {
-        if (Array.isArray(namingConvention)) {
-          reNaming = new RegExp(namingConvention.join('|'))
-        } else {
-          reNaming = new RegExp(namingConvention)
-        }
         if (!reNaming.test(secretProperty)) {
           allowed = false
           reason = `key name ${secretProperty} does not match naming convention ${namingConvention}`

--- a/lib/poller.test.js
+++ b/lib/poller.test.js
@@ -876,6 +876,41 @@ describe('Poller', () => {
             ]
           },
           permitted: false
+        },
+        {
+          // test multiple regex data
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: ['dev/team-a/.*', 'common/.*'] } } },
+          descriptor: {
+            data: [
+              { key: 'dev/team-a/ok-secret', name: 'somethingelse' },
+              { key: 'common/generic-secret', name: 'genericsecret' }
+            ]
+          },
+          permitted: true
+        },
+        {
+          // test multiple regex data
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: ['dev/team-a/.*', 'common/.*'] } } },
+          descriptor: {
+            data: [
+              { key: 'dev/team-b/nok-secret', name: 'somethingelse' },
+              { key: 'common/generic-secret', name: 'genericsecret' }
+            ]
+          },
+          permitted: false
+        },
+        {
+          // test multiple regex data
+          ns: { metadata: { annotations: { [namingPermittedAnnotation]: ['dev/team-b/.*', 'common/.*'] } } },
+          descriptor: {
+            data: [
+              { key: 'common/generic-secret', name: 'genericsecret' }
+            ],
+            dataFrom: [
+              'common/generic-secret'
+            ]
+          },
+          permitted: true
         }
       ]
 


### PR DESCRIPTION
While documentation says that `permitted-key-name` can be provided as regular expression
```
kind: Namespace
metadata:
  name: core-namespace
  annotations:
    # annotation key is configurable
    externalsecrets.kubernetes-client.io/permitted-key-name: "/dev/cluster1/core-namespace/.*"
```
it would be nice (clearer ?) if it can support _list_ of regular expressions
```
kind: Namespace
metadata:
  name: core-namespace
  annotations:
    # annotation key is configurable
    externalsecrets.kubernetes-client.io/permitted-key-name:
      - "/dev/cluster1/core-namespace/.*"
      - "/common/.*"
```