### PR TITLE
feat: bump kindest/node version

### DIFF
--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -35,7 +35,7 @@ RED='\e[35m'
 NC='\e[0m'
 BGREEN='\e[32m'
 
-K8S_VERSION=${K8S_VERSION:-v1.15.3}
+K8S_VERSION=${K8S_VERSION:-v1.15.11}
 KIND_CLUSTER_NAME="external-secrets-dev"
 REGISTRY=external-secrets
 


### PR DESCRIPTION
For some reason, in cluster started by `kind`, `core-dns` doesn't start
```
plugin/loop: Loop (127.0.0.1:55953 -> :1053) detected for zone ".", see https://coredns.io/plugins/loop#troubleshooting.
```
which messes with internal cluster communication between services and makes e2e tests to fails due to timeout 
```
     Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/app/e2e/tests/secrets-man
ager.test.js)                                                                                                                                                         
      at listOnTimeout (internal/timers.js:549:17)                                                                                                                    
      at processTimers (internal/timers.js:492:7)
```
A lot of [PRs](https://github.com/godaddy/kubernetes-external-secrets/pulls) are failing for not _legitimate_ reason

Using a more recent version of `kindest/node` makes test pass again.

```
$> ./run-e2e-suite.sh true 2
...
Starting external-secrets e2e tests...                                                                                                                                
Waiting for deployment "localstack" rollout to finish: 0 of 1 updated replicas are available...                                                                       
deployment "localstack" successfully rolled out                                                                                                                       
deployment "e2e-kubernetes-external-secrets" successfully rolled out                                                                                                  
If you don't see a command prompt, try pressing enter.                                                                                                                


  CRD
    ✓ ensure CRD is managed correctly
    ✓ should reject invalid ExternalSecret manifests

  secretsmanager
    ✓ should pull existing secret from secretsmanager and create a secret with its values (2151ms)                                                                   
    ✓ should pull TLS secret from secretsmanager (145ms)
    permitted annotation
      ✓ should not pull from secretsmanager (3477ms)

  ssm
    ✓ should pull existing secret from ssm and create a secret from it (135ms)
    permitted annotation
      ✓ should not pull from ssm (3477ms)


  7 passing (10s)
...
```