### PR TITLE
add support for assumeRoleWithWebIdentity when used on AWS Fargate IRSA

### DIFF
--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -52,7 +52,7 @@ module.exports = {
         })
       })
     }
-      
+
     return new Promise((resolve, reject) => {
       sts.assumeRole(assumeRoleOpts, (err, res) => {
         if (err) {

--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -6,6 +6,7 @@ const clonedeep = require('lodash.clonedeep')
 const merge = require('lodash.merge')
 
 const localstack = process.env.LOCALSTACK || 0
+const webIdentity = process.env.AWS_WEB_IDENTITY_TOKEN_FILE || 0
 
 let secretsManagerConfig = {}
 let systemManagerConfig = {}
@@ -41,6 +42,17 @@ module.exports = {
   },
   assumeRole: (assumeRoleOpts) => {
     const sts = new AWS.STS(stsConfig)
+    if (webIdentity) {
+      return new Promise((resolve, reject) => {
+        sts.assumeRoleWithWebIdentity(assumeRoleOpts, (err, res) => {
+          if (err) {
+            return reject(err)
+          }
+          resolve(res)
+        })
+      })
+    }
+      
     return new Promise((resolve, reject) => {
       sts.assumeRole(assumeRoleOpts, (err, res) => {
         if (err) {


### PR DESCRIPTION
This PR adds support for AWS IAM authentication using web identity token file. Primary use case is Fargate IRSA.

Summary:

* when env variable AWS_WEB_IDENTITY_TOKEN_FILE is present the contoller will now use assumeRoleWithWebIdentity
* chart has to be deployed with --set securityContext.fsGroup=65534 in order to access web identity token

Closes #254 