### PR TITLE
fix: Additional quotes added while creating secret

### DIFF
--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -53,7 +53,12 @@ class VaultBackend extends KVBackend {
     this._logger.debug(`reading secret key ${key} from vault`)
     const secretResponse = await this._client.read(key)
 
-    return JSON.stringify(secretResponse.data.data)
+    /**return JSON.stringify(secretResponse.data.data)
+    As the stringify adds addtional double quotes to the data that is retrieved
+    from the Vault in JSON format we need to parse it to have actual data rather than
+    having a double quotes added data content.**/
+    const secretValue = JSON.stringify(secretResponse.data.data)
+    return JSON.parse(secretValue)
   }
 }
 

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -53,10 +53,10 @@ class VaultBackend extends KVBackend {
     this._logger.debug(`reading secret key ${key} from vault`)
     const secretResponse = await this._client.read(key)
 
-    /**return JSON.stringify(secretResponse.data.data)
+    /** return JSON.stringify(secretResponse.data.data)
     As the stringify adds addtional double quotes to the data that is retrieved
     from the Vault in JSON format we need to parse it to have actual data rather than
-    having a double quotes added data content.**/
+    having a double quotes added data content. **/
     const secretValue = JSON.stringify(secretResponse.data.data)
     return JSON.parse(secretValue)
   }

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -19,7 +19,7 @@ describe('VaultBackend', () => {
   const role = 'fakeRole'
   const secretKey = 'fakeSecretKey'
   const secretValue = 'open, sesame'
-  const quotedSecretValue = '"' + secretValue + '"'
+  const quotedSecretValue = secretValue
   const quotedSecretValueAsBase64 = Buffer.from(quotedSecretValue).toString('base64')
   const jwt = 'this-is-a-jwt-token'
 


### PR DESCRIPTION
As the JSON.stringify adds additional quotes when it reads the json data from the vault and while creating the secret object in K8s it adds additional quotes to avoid it just we need to make sure it is parsed to remove it and have only the actual value used for the secret in K8s. I have made this change in my usage and it is working perfectly fine.