### PR TITLE
feat: add support for using either Vault k/v 1 or k/v 2

### DIFF
--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -55,6 +55,11 @@ spec:
               type: string
             vaultMountPoint:
               type: string
+            kvVersion:
+              description: Vault K/V version either 1 or 2, default = 2
+              type: integer
+              minimum: 1
+              maximum: 2
             keyVaultName:
               type: string
             key:

--- a/examples/vault-kv1.yaml
+++ b/examples/vault-kv1.yaml
@@ -1,13 +1,16 @@
 apiVersion: 'kubernetes-client.io/v1'
 kind: ExternalSecret
 metadata:
-  name: hello-service
+  name: database-credentials-from-kv1
 spec:
   backendType: vault
   vaultMountPoint: my-kubernetes-vault-mount-point
   vaultRole: my-vault-role
-  kvVersion: 2 # defaults to 2
+  kvVersion: 1
   data:
+    - name: username
+      key: kv/database
+      property: db-username
     - name: password
-      key: secret/data/hello-service/password
-      property: password
+      key: kv/database
+      property: db-password

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -33,9 +33,10 @@ class VaultBackend extends KVBackend {
    * @param {object} specOptions - Options for this external secret, eg role
    * @param {string} specOptions.vaultMountPoint - mount point
    * @param {string} specOptions.vaultRole - role
+   * @param {number} specOptions.kvVersion - K/V Version 1 or 2
    * @returns {Promise} Promise object representing secret property values.
    */
-  async _get ({ key, specOptions: { vaultMountPoint, vaultRole } }) {
+  async _get ({ key, specOptions: { vaultMountPoint, vaultRole, kvVersion = 2 } }) {
     if (!this._client.token) {
       const jwt = this._fetchServiceAccountToken()
       this._logger.debug('fetching new token from vault')
@@ -53,7 +54,15 @@ class VaultBackend extends KVBackend {
     this._logger.debug(`reading secret key ${key} from vault`)
     const secretResponse = await this._client.read(key)
 
-    return JSON.stringify(secretResponse.data.data)
+    if (kvVersion === 1) {
+      return JSON.stringify(secretResponse.data)
+    }
+
+    if (kvVersion === 2) {
+      return JSON.stringify(secretResponse.data.data)
+    }
+
+    throw new Error('Unknown "kvVersion" specified')
   }
 }
 

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -19,9 +19,20 @@ describe('VaultBackend', () => {
   const role = 'fakeRole'
   const secretKey = 'fakeSecretKey'
   const secretValue = 'open, sesame'
-  const quotedSecretValue = '"' + secretValue + '"'
+  const secretData = { [secretKey]: secretValue }
+  const quotedSecretValue = JSON.stringify(secretData)
   const quotedSecretValueAsBase64 = Buffer.from(quotedSecretValue).toString('base64')
   const jwt = 'this-is-a-jwt-token'
+
+  const kv1Secret = {
+    data: secretData
+  }
+
+  const kv2Secret = {
+    data: {
+      data: secretData
+    }
+  }
 
   beforeEach(() => {
     clientMock = sinon.mock()
@@ -34,11 +45,7 @@ describe('VaultBackend', () => {
 
   describe('_get', () => {
     beforeEach(() => {
-      clientMock.read = sinon.stub().returns({
-        data: {
-          data: secretValue
-        }
-      })
+      clientMock.read = sinon.stub().returns(kv2Secret)
       clientMock.tokenRenewSelf = sinon.stub().returns(true)
       clientMock.kubernetesLogin = sinon.stub().returns({
         auth: {
@@ -51,11 +58,63 @@ describe('VaultBackend', () => {
       clientMock.token = undefined
     })
 
-    it('logs in and returns secret property value', async () => {
+    it('logs in and returns secret property value - default', async () => {
       const secretPropertyValue = await vaultBackend._get({
         specOptions: {
           vaultMountPoint: mountPoint,
           vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // First, we log into Vault...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals(quotedSecretValue)
+    })
+
+    it('logs in and returns secret property value - kv version 1', async () => {
+      clientMock.read = sinon.stub().returns(kv1Secret)
+
+      const secretPropertyValue = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role,
+          kvVersion: 1
+        },
+        key: secretKey
+      })
+
+      // First, we log into Vault...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals(quotedSecretValue)
+    })
+
+    it('logs in and returns secret property value - kv version 2', async () => {
+      clientMock.read = sinon.stub().returns(kv2Secret)
+
+      const secretPropertyValue = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role,
+          kvVersion: 2
         },
         key: secretKey
       })
@@ -101,7 +160,7 @@ describe('VaultBackend', () => {
 
   describe('getSecretManifestData', () => {
     beforeEach(() => {
-      clientMock.read = sinon.stub().returns({ data: { data: secretValue } })
+      clientMock.read = sinon.stub().returns(kv2Secret)
       clientMock.tokenRenewSelf = sinon.stub().returns(true)
       clientMock.kubernetesLogin = sinon.stub().returns({ auth: { client_token: '1234' } })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5448,9 +5448,9 @@
       }
     },
     "node-vault": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.9.11.tgz",
-      "integrity": "sha512-v4xfXtuJuVzQrf8yYh+8/z7yf+UA4O4W0YaOF4rl4TBjK03ryKZnSNnTpfxYTL22pzc9bg7SsLwXi3pWKnACwg==",
+      "version": "0.9.18",
+      "resolved": "https://registry.npmjs.org/node-vault/-/node-vault-0.9.18.tgz",
+      "integrity": "sha512-fYLRreig5zKcqxr5tUR+KWMwQy+/KQUI6qVj6jSuePmJg9Tv4YRFP6MrwlujVTaxUBzJLylkRGnW224Q0KkrPA==",
       "requires": {
         "debug": "3.1.0",
         "mustache": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "@alicloud/kms20160120": "^1.1.0",
     "@azure/identity": "^1.0.2",
     "@azure/keyvault-secrets": "^4.0.2",
-    "aws-sdk": "^2.628.0",
     "@google-cloud/secret-manager": "^1.2.1",
+    "aws-sdk": "^2.628.0",
     "express": "^4.17.1",
     "js-yaml": "^3.13.1",
     "json-stream": "^1.0.0",
@@ -43,7 +43,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "make-promises-safe": "^5.1.0",
-    "node-vault": "^0.9.8",
+    "node-vault": "^0.9.18",
     "pino": "^6.0.0",
     "prom-client": "^12.0.0"
   },


### PR DESCRIPTION
Closes #299
Fixes #248 
Closes #425 
Closes #349 

Adds a `kvVersion` flag to vault backend:

```yaml
apiVersion: 'kubernetes-client.io/v1'
kind: ExternalSecret
metadata:
  name: database-credentials-from-kv1
spec:
  backendType: vault
  vaultMountPoint: my-kubernetes-vault-mount-point
  vaultRole: my-vault-role
  kvVersion: 1 # <---------- K/V version to be able to parse api response correctly
  data:
    - name: username
      key: kv/database
      property: db-username
    - name: password
      key: kv/database
      property: db-password
```