### PR TITLE
Switch to human-readable log levels

### DIFF
--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -16,6 +16,8 @@ env:
   AWS_DEFAULT_REGION: us-west-2
   POLLER_INTERVAL_MILLISECONDS: 10000  # Caution, setting this frequency may incur additional charges on some platforms
   LOG_LEVEL: info
+  # Print logs level as string ("info") rather than integer (30)
+  # USE_HUMAN_READABLE_LOG_LEVELS: true
   METRICS_PORT: 3001
   VAULT_ADDR: http://127.0.0.1:8200
 #  GOOGLE_APPLICATION_CREDENTIALS: /app/gcp-creds/gcp-creds.json
@@ -52,9 +54,6 @@ env:
 #   gcp-creds:
 #     secret: gcp-creds
 #     mountPath: /app/gcp-creds
-
-  # Print logs level as string ("info") rather than integer (30)
-  USE_HUMAN_READABLE_LOG_LEVELS: false
 
 rbac:
   # Specifies whether RBAC resources should be created

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -53,6 +53,9 @@ env:
 #     secret: gcp-creds
 #     mountPath: /app/gcp-creds
 
+  # Print logs level as string ("info") rather than integer (30)
+  USE_HUMAN_READABLE_LOG_LEVELS: false
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/config/environment.js
+++ b/config/environment.js
@@ -24,6 +24,9 @@ const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 const logLevel = process.env.LOG_LEVEL || 'info'
+const useHumanReadableLogLevels = process.env.USE_HUMAN_READABLE_LOG_LEVELS
+  ? true : false
+
 const pollingDisabled = 'DISABLE_POLLING' in process.env
 
 const rolePermittedAnnotation = process.env.ROLE_PERMITTED_ANNOTATION || 'iam.amazonaws.com/permitted'
@@ -43,5 +46,6 @@ module.exports = {
   namingPermittedAnnotation,
   pollingDisabled,
   logLevel,
-  customResourceManagerDisabled
+  customResourceManagerDisabled,
+  useHumanReadableLogLevels
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -24,7 +24,7 @@ const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 const logLevel = process.env.LOG_LEVEL || 'info'
-const useHumanReadableLogLevels = !!process.env.USE_HUMAN_READABLE_LOG_LEVELS
+const useHumanReadableLogLevels = 'USE_HUMAN_READABLE_LOG_LEVELS' in process.env
 
 const pollingDisabled = 'DISABLE_POLLING' in process.env
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -24,8 +24,7 @@ const pollerIntervalMilliseconds = process.env.POLLER_INTERVAL_MILLISECONDS
   ? Number(process.env.POLLER_INTERVAL_MILLISECONDS) : 10000
 
 const logLevel = process.env.LOG_LEVEL || 'info'
-const useHumanReadableLogLevels = process.env.USE_HUMAN_READABLE_LOG_LEVELS
-  ? true : false
+const useHumanReadableLogLevels = !!process.env.USE_HUMAN_READABLE_LOG_LEVELS
 
 const pollingDisabled = 'DISABLE_POLLING' in process.env
 

--- a/config/index.js
+++ b/config/index.js
@@ -36,7 +36,7 @@ const logger = pino({
     err: pino.stdSerializers.err
   },
   level: envConfig.logLevel,
-  useLevelLabels: true
+  useLevelLabels: envConfig.useHumanReadableLogLevels
 })
 
 const customResourceManager = new CustomResourceManager({

--- a/config/index.js
+++ b/config/index.js
@@ -35,7 +35,8 @@ const logger = pino({
   serializers: {
     err: pino.stdSerializers.err
   },
-  level: envConfig.logLevel
+  level: envConfig.logLevel,
+  useLevelLabels: true
 })
 
 const customResourceManager = new CustomResourceManager({


### PR DESCRIPTION
Switch from the following log messages:

```
{"level":30,"time":1594499119283,"pid":18,"hostname":"kubernetes-external-secrets-56d5969cd6-gdkb4","msg":"starting poller for asdf/database-credentials"}
```

to 

```
{"level":"info","time":1594499119283,"pid":18,"hostname":"kubernetes-external-secrets-56d5969cd6-gdkb4","msg":"starting poller for asdf/database-credentials"}
```

Many log aggregation tools parse the logs for human readable log levels like "warning" or "error". This makes it easier to send alerts based on those logs, etc.