### PR TITLE
fix: reverts assumeRole to use pod role instead of web identity

### DIFF
--- a/config/aws-config.js
+++ b/config/aws-config.js
@@ -4,10 +4,8 @@
 const AWS = require('aws-sdk')
 const clonedeep = require('lodash.clonedeep')
 const merge = require('lodash.merge')
-const fs = require('fs')
 
 const localstack = process.env.LOCALSTACK || 0
-const webIdentity = process.env.AWS_WEB_IDENTITY_TOKEN_FILE || 0
 
 let secretsManagerConfig = {}
 let systemManagerConfig = {}
@@ -31,10 +29,6 @@ if (localstack) {
   }
 }
 
-function loadServiceToken () {
-  return fs.readFileSync(webIdentity, 'utf8')
-}
-
 module.exports = {
   secretsManagerFactory: (opts = {}) => {
     if (localstack) {
@@ -50,16 +44,6 @@ module.exports = {
   },
   assumeRole: (assumeRoleOpts) => {
     const sts = new AWS.STS(stsConfig)
-    if (webIdentity) {
-      return new Promise((resolve, reject) => {
-        sts.assumeRoleWithWebIdentity(merge(assumeRoleOpts, { WebIdentityToken: loadServiceToken() }), (err, res) => {
-          if (err) {
-            return reject(err)
-          }
-          resolve(res)
-        })
-      })
-    }
 
     return new Promise((resolve, reject) => {
       sts.assumeRole(assumeRoleOpts, (err, res) => {


### PR DESCRIPTION
Fixes #442, see https://github.com/godaddy/kubernetes-external-secrets/issues/442#issuecomment-664084389 for more details

Effectively reverts changes introduced in #416 and #417 