### PR TITLE
fix(azure)!: Changes the values return type from Azure Key vault Prev…

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,6 @@ spec:
   data:
     - key: hello-service/credentials
       name: password
-      property: value
 ```
 
 Due to the way Azure handles binary files, you need to explicitly let the ExternalSecret know that the secret is binary.

--- a/lib/backends/azure-keyvault-backend.js
+++ b/lib/backends/azure-keyvault-backend.js
@@ -38,7 +38,7 @@ class AzureKeyVaultBackend extends KVBackend {
     if (keyOptions && keyOptions.isBinary) {
       return Buffer.from(secret.value, 'base64')
     }
-    return JSON.stringify(secret)
+    return secret.value
   }
 }
 

--- a/lib/backends/azure-keyvault-backend.test.js
+++ b/lib/backends/azure-keyvault-backend.test.js
@@ -15,13 +15,20 @@ describe('AzureKeyVaultBackend', () => {
   const secret = 'fakeSecretPropertyValue'
   const key = 'password'
   const keyVaultName = 'vault_name'
-  const quotedSecretValue = '"' + secret + '"'
+  const quotedSecretValueAsBase64 = Buffer.from(secret).toString('base64')
+
+  const azureSecret = {
+    properties: {},
+    value: secret,
+    name: key
+  }
 
   beforeEach(() => {
     credentialMock = sinon.mock()
     loggerMock = sinon.mock()
     credentialFactoryMock = sinon.fake.returns(credentialMock)
     clientMock = sinon.mock()
+    clientMock.getSecret = sinon.stub().returns(azureSecret)
     loggerMock.info = sinon.stub()
 
     azureKeyVaultBackend = new AzureKeyVaultBackend({
@@ -32,10 +39,6 @@ describe('AzureKeyVaultBackend', () => {
   })
 
   describe('_get', () => {
-    beforeEach(() => {
-      clientMock.getSecret = sinon.stub().returns(secret)
-    })
-
     it('returns secret property value', async () => {
       const secretPropertyValue = await azureKeyVaultBackend._get({
         key: key,
@@ -43,7 +46,31 @@ describe('AzureKeyVaultBackend', () => {
           keyVaultName: keyVaultName
         }
       })
-      expect(secretPropertyValue).equals(quotedSecretValue)
+      expect(secretPropertyValue).equals(secret)
+    })
+  })
+
+  describe('getSecretManifestData', () => {
+    it('returns secret property value', async () => {
+      const returnedData = await azureKeyVaultBackend.getSecretManifestData({
+        spec: {
+          backendType: 'vault',
+          keyVaultName: keyVaultName,
+          data: [{
+            key: key,
+            name: 'name-in-k8s'
+          }]
+        }
+      })
+
+      // First, we get the client...
+      sinon.assert.calledWith(azureKeyVaultBackend._keyvaultClient, { keyVaultName })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.getSecret, key)
+
+      // ... and expect to get the full proper value
+      expect(returnedData['name-in-k8s']).equals(quotedSecretValueAsBase64)
     })
   })
 })


### PR DESCRIPTION
**This is a breaking change** for azure key vault users

fix(azure)!: Changes the values return type from Azure Key vault Previously secret value was wrapped in an object { "value": <secret> } while now <secret> will be returned directly so KES features can be properly used (migration: "property: value" -> remove property selector)

Allows storing JSON in azure vault backend and extracting fields etc!

eg

Secret values in azure keyvault:

`password=lolsogood`
`credentials={"username":"wtf","password":"lol","host":"greenland"}`

```yaml
apiVersion: 'kubernetes-client.io/v1'
kind: ExternalSecret
metadata:
  name: hello-service-azure
spec:
  backendType: azureKeyVault
  keyVaultName: kes-test
  data:
    - key: password
      name: password
    - key: credentials
      name: username
      property: username
```

-> 

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: hello-service-azure
  namespace: default
type: Opaque
data:
  password: bG9sc29nb29k
  username: d3Rm
```

and (removing property selector for credentials)

```yaml
apiVersion: 'kubernetes-client.io/v1'
kind: ExternalSecret
metadata:
  name: hello-service-azure
spec:
  backendType: azureKeyVault
  keyVaultName: kes-test
  data:
    - key: password
      name: password
    - key: credentials
      name: username
```

-> 

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: hello-service-azure
  namespace: default
type: Opaque
data:
  password: bG9sc29nb29k
  username: eyJ1c2VybmFtZSI6Ind0ZiIsInBhc3N3b3JkIjoibG9sIiwiaG9zdCI6ImdyZWVubGFuZCJ9
```

Currently you have to do:

```yaml
apiVersion: 'kubernetes-client.io/v1'
kind: ExternalSecret
metadata:
  name: hello-service-azure
spec:
  backendType: azureKeyVault
  keyVaultName: kes-test
  data:
    - key: password
      name: password
      property: value
    - key: credentials
      name: username
      property: value
```

which limits KES usability.
