### PR TITLE
Added section for non-opaque secrets creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,6 @@ secretDescriptor:
       name: .dockerconfigjson
 ```
 
-
 ## Enforcing naming conventions for backend keys
 
 by default an `ExternalSecret` may access arbitrary keys from the backend e.g.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,25 @@ data:
   password: MTIzNA==
 ```
 
+### Create secrets of other types than opaque
+
+You can override `ExternalSecret` type using `template`, for example:
+
+```yaml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: hello-docker
+secretDescriptor:
+  backendType: systemManager
+  template:
+    type: kubernetes.io/dockerconfigjson
+  data:
+    - key: /hello-service/hello-docker
+      name: .dockerconfigjson
+```
+
+
 ## Enforcing naming conventions for backend keys
 
 by default an `ExternalSecret` may access arbitrary keys from the backend e.g.


### PR DESCRIPTION
This pr adds a tiny section on how to create non-opaque secrets (using template). Currently you have to search through issues in order to find this information (for example #359)