### PR TITLE
doc: use new API standard in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
   name: hello-docker
-secretDescriptor:
+spec:
   backendType: systemManager
   template:
     type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
The `SecretDescriptor` property was still used in an example, even though `spec` has been the norm for a while now. This helps correct behavior for people copy-pasting code.