### PR TITLE
feat(aws): add region support to ssm and sm

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ spec:
   backendType: secretsManager
   # optional: specify role to assume when retrieving the data
   roleArn: arn:aws:iam::123456789012:role/test-role
+  # optional: specify region
+  region: us-east-1
   data:
     - key: hello-service/credentials
       name: password
@@ -315,6 +317,8 @@ spec:
   backendType: secretsManager
   # optional: specify role to assume when retrieving the data
   roleArn: arn:aws:iam::123456789012:role/test-role
+  # optional: specify region
+  region: us-east-1
   dataFrom:
     - hello-service/credentials
 ```
@@ -330,6 +334,8 @@ spec:
   backendType: secretsManager
   # optional: specify role to assume when retrieving the data
   roleArn: arn:aws:iam::123456789012:role/test-role
+  # optional: specify region
+  region: us-east-1
   dataFrom:
     - hello-service/credentials
   data:

--- a/examples/secretsmanager-example.yaml
+++ b/examples/secretsmanager-example.yaml
@@ -6,6 +6,8 @@ spec:
   backendType: secretsManager
   # optional: specify role to assume when retrieving the data
   roleArn: arn:aws:iam::123412341234:role/let-other-account-access-secrets
+  # optional: specify region of the secret
+  region: eu-west-1
   data:
     - key: demo-service/credentials
       name: password

--- a/examples/ssm-example.yaml
+++ b/examples/ssm-example.yaml
@@ -6,6 +6,8 @@ spec:
   backendType: systemManager
   # optional: specify role to assume when retrieving the data
   roleArn: arn:aws:iam::123456789012:role/test-role
+  # optional: specify region
+  region: eu-west-1
   data:
     - key: /foo/name1
       name: variable-name

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -296,7 +296,7 @@ describe('kv-backend', () => {
       expect(manifestData).deep.equals({})
     })
 
-    it('makes correct calls - with data and role', async () => {
+    it('makes correct calls - with data, role and region', async () => {
       await kvBackend.getSecretManifestData({
         spec: {
           data: [
@@ -308,7 +308,8 @@ describe('kv-backend', () => {
               name: 'fakePropertyName2'
             }
           ],
-          roleArn: 'my-role'
+          roleArn: 'my-role',
+          region: 'my-region'
         }
       })
 
@@ -320,12 +321,18 @@ describe('kv-backend', () => {
           key: 'fakePropertyKey2',
           name: 'fakePropertyName2'
         }],
-        specOptions: { roleArn: 'my-role' }
+        specOptions: {
+          roleArn: 'my-role',
+          region: 'my-region'
+        }
       })).to.equal(true)
 
       expect(kvBackend._fetchDataFromValues.calledWith({
         dataFrom: [],
-        specOptions: { roleArn: 'my-role' }
+        specOptions: {
+          roleArn: 'my-role',
+          region: 'my-region'
+        }
       })).to.equal(true)
     })
 

--- a/lib/backends/secrets-manager-backend.js
+++ b/lib/backends/secrets-manager-backend.js
@@ -26,20 +26,30 @@ class SecretsManagerBackend extends KVBackend {
    * @param {string} specOptions.roleArn - IAM role arn to assume
    * @returns {Promise} Promise object representing secret property value.
    */
-  async _get ({ key, specOptions: { roleArn }, keyOptions: { versionStage = 'AWSCURRENT', versionId = null } }) {
-    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'}`)
+  async _get ({ key, specOptions: { roleArn, region }, keyOptions: { versionStage = 'AWSCURRENT', versionId = null } }) {
+    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'} in region ${region}`)
 
     let client = this._client
+    let factoryArgs = null
     if (roleArn) {
       const credentials = this._assumeRole({
         RoleArn: roleArn,
         RoleSessionName: 'k8s-external-secrets'
       })
-      client = this._clientFactory({
+      factoryArgs = {
+        ...factoryArgs,
         credentials
-      })
+      }
     }
-
+    if (region) {
+      factoryArgs = {
+        ...factoryArgs,
+        region
+      }
+    }
+    if (factoryArgs) {
+      client = this._clientFactory(factoryArgs)
+    }
     let params
     if (versionId) {
       params = { SecretId: key, VersionId: versionId }

--- a/lib/backends/secrets-manager-backend.test.js
+++ b/lib/backends/secrets-manager-backend.test.js
@@ -81,19 +81,23 @@ describe('SecretsManagerBackend', () => {
       expect(secretPropertyValue.toString()).equals('fakeSecretPropertyValue')
     })
 
-    it('returns secret property value assuming a role', async () => {
+    it('returns secret property value assuming a role with region', async () => {
       getSecretValuePromise.promise.resolves({
         SecretString: 'fakeAssumeRoleSecretValue'
       })
 
       const secretPropertyValue = await secretsManagerBackend._get({
         key: 'fakeSecretKey',
-        specOptions: { roleArn: 'my-role' },
+        specOptions: {
+          roleArn: 'my-role',
+          region: 'foo-bar-baz'
+        },
         keyOptions
       })
 
       expect(clientFactoryMock.lastArg).deep.equals({
-        credentials: assumeRoleCredentials
+        credentials: assumeRoleCredentials,
+        region: 'foo-bar-baz'
       })
       expect(clientMock.getSecretValue.calledWith({
         SecretId: 'fakeSecretKey',
@@ -101,9 +105,36 @@ describe('SecretsManagerBackend', () => {
       })).to.equal(true)
       expect(clientFactoryMock.getCall(0).args).deep.equals([])
       expect(clientFactoryMock.getCall(1).args).deep.equals([{
-        credentials: assumeRoleCredentials
+        credentials: assumeRoleCredentials,
+        region: 'foo-bar-baz'
       }])
       expect(assumeRoleMock.callCount).equals(1)
+      expect(secretPropertyValue).equals('fakeAssumeRoleSecretValue')
+    })
+
+    it('returns secret property value from specific region', async () => {
+      getSecretValuePromise.promise.resolves({
+        SecretString: 'fakeAssumeRoleSecretValue'
+      })
+
+      const secretPropertyValue = await secretsManagerBackend._get({
+        key: 'fakeSecretKey',
+        specOptions: { region: 'my-region' },
+        keyOptions
+      })
+
+      expect(clientFactoryMock.lastArg).deep.equals({
+        region: 'my-region'
+      })
+      expect(clientMock.getSecretValue.calledWith({
+        SecretId: 'fakeSecretKey',
+        VersionStage: 'AWSCURRENT'
+      })).to.equal(true)
+      expect(clientFactoryMock.getCall(0).args).deep.equals([])
+      expect(clientFactoryMock.getCall(1).args).deep.equals([{
+        region: 'my-region'
+      }])
+      expect(assumeRoleMock.callCount).equals(0)
       expect(secretPropertyValue).equals('fakeAssumeRoleSecretValue')
     })
 

--- a/lib/backends/system-manager-backend.js
+++ b/lib/backends/system-manager-backend.js
@@ -19,23 +19,33 @@ class SystemManagerBackend extends KVBackend {
   /**
    * Get secret property value from System Manager.
    * @param {string} key - Key used to store secret property value in System Manager.
-   * @param {object} keyOptions - Options for this specific key, eg version etc.
    * @param {object} specOptions - Options for this external secret, eg role
    * @param {string} specOptions.roleArn - IAM role arn to assume
    * @returns {Promise} Promise object representing secret property value.
    */
-  async _get ({ key, specOptions: { roleArn } }) {
-    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'}`)
+  async _get ({ key, specOptions: { roleArn, region } }) {
+    this._logger.info(`fetching secret property ${key} with role: ${roleArn || 'pods role'} in region ${region}`)
 
     let client = this._client
+    let factoryArgs = null
     if (roleArn) {
       const credentials = this._assumeRole({
         RoleArn: roleArn,
         RoleSessionName: 'k8s-external-secrets'
       })
-      client = this._clientFactory({
+      factoryArgs = {
+        ...factoryArgs,
         credentials
-      })
+      }
+    }
+    if (region) {
+      factoryArgs = {
+        ...factoryArgs,
+        region
+      }
+    }
+    if (factoryArgs) {
+      client = this._clientFactory(factoryArgs)
     }
     try {
       const data = await client

--- a/lib/backends/system-manager-backend.test.js
+++ b/lib/backends/system-manager-backend.test.js
@@ -63,7 +63,7 @@ describe('SystemManagerBackend', () => {
       expect(secretPropertyValue).equals('fakeSecretPropertyValue')
     })
 
-    it('returns secret property value assuming a role', async () => {
+    it('returns secret property value assuming a role with region', async () => {
       getParameterPromise.promise.resolves({
         Parameter: {
           Value: 'fakeAssumeRoleSecretValue'
@@ -72,10 +72,14 @@ describe('SystemManagerBackend', () => {
 
       const secretPropertyValue = await systemManagerBackend._get({
         key: 'fakeSecretKey',
-        specOptions: { roleArn: 'my-role' }
+        specOptions: {
+          roleArn: 'my-role',
+          region: 'my-region'
+        }
       })
       expect(clientFactoryMock.lastArg).deep.equals({
-        credentials: assumeRoleCredentials
+        credentials: assumeRoleCredentials,
+        region: 'my-region'
       })
       expect(clientMock.getParameter.calledWith({
         Name: 'fakeSecretKey',
@@ -83,9 +87,39 @@ describe('SystemManagerBackend', () => {
       })).to.equal(true)
       expect(clientFactoryMock.getCall(0).args).deep.equals([])
       expect(clientFactoryMock.getCall(1).args).deep.equals([{
-        credentials: assumeRoleCredentials
+        credentials: assumeRoleCredentials,
+        region: 'my-region'
+      }])
+      expect(assumeRoleMock.callCount).equals(1)
+      expect(secretPropertyValue).equals('fakeAssumeRoleSecretValue')
+    })
+
+    it('returns secret property value from specific region', async () => {
+      getParameterPromise.promise.resolves({
+        Parameter: {
+          Value: 'fakeAssumeRoleSecretValue'
+        }
+      })
+
+      const secretPropertyValue = await systemManagerBackend._get({
+        key: 'fakeSecretKey',
+        specOptions: {
+          region: 'my-region'
+        }
+      })
+      expect(clientFactoryMock.lastArg).deep.equals({
+        region: 'my-region'
+      })
+      expect(clientMock.getParameter.calledWith({
+        Name: 'fakeSecretKey',
+        WithDecryption: true
+      })).to.equal(true)
+      expect(clientFactoryMock.getCall(0).args).deep.equals([])
+      expect(clientFactoryMock.getCall(1).args).deep.equals([{
+        region: 'my-region'
       }])
       expect(secretPropertyValue).equals('fakeAssumeRoleSecretValue')
+      expect(assumeRoleMock.callCount).equals(0)
     })
 
     it('throws a meaningful message when the parameter does not exist', async () => {


### PR DESCRIPTION
This PR adds multi-region support for ssm and sm #354

I feel like we should (somehow) cache & reuse the ssm/sm `client` object so we don't assume a role in each `_get` call. E.g. by using the hash of the `ExternalSecret` or `${namespace}/${name}/${metadata.generation}` as cache key for the client object.