### PR TITLE
Provide a meaningful error message when an SSM parameter is missing

### DIFF
--- a/lib/backends/system-manager-backend.js
+++ b/lib/backends/system-manager-backend.js
@@ -39,13 +39,21 @@ class SystemManagerBackend extends KVBackend {
         sessionToken: res.Credentials.SessionToken
       })
     }
-    const data = await client
-      .getParameter({
-        Name: key,
-        WithDecryption: true
-      })
-      .promise()
-    return data.Parameter.Value
+    try {
+      const data = await client
+        .getParameter({
+          Name: key,
+          WithDecryption: true
+        })
+        .promise()
+      return data.Parameter.Value
+    } catch (err) {
+      if (err.code === 'ParameterNotFound' && (!err.message || err.message === 'null')) {
+        err.message = `ParameterNotFound: ${key} could not be found.`
+      }
+
+      throw err
+    }
   }
 }
 

--- a/lib/backends/system-manager-backend.test.js
+++ b/lib/backends/system-manager-backend.test.js
@@ -95,5 +95,22 @@ describe('SystemManagerBackend', () => {
       }])
       expect(secretPropertyValue).equals('fakeAssumeRoleSecretValue')
     })
+
+    it('throws a meaningful message when the parameter does not exist', async () => {
+      const error = new Error(null)
+      error.code = 'ParameterNotFound'
+      error.name = 'ParameterNotFound'
+
+      getParameterPromise.promise.rejects(error)
+
+      try {
+        await systemManagerBackend._get({
+          key: 'fakeSecretKey',
+          specOptions
+        })
+      } catch (err) {
+        expect(err.message).equals('ParameterNotFound: fakeSecretKey could not be found.')
+      }
+    })
   })
 })


### PR DESCRIPTION
Related to https://github.com/godaddy/kubernetes-external-secrets/issues/265

When a requested key does not exist in AWS SSM the Externalsecret status currently reads `ERROR, null` because the AWS error has 'null' as its message. This change would add a meaningful error message.
The issue mentioned above suggests to skip the missing key. I think that would mask the underlying problem though. Let me know what you prefer.