### PR TITLE
Cache Vault clients/tokens on a per-role&mountpoint basis.

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -76,14 +76,15 @@ if (envConfig.vaultNamespace) {
     'X-VAULT-NAMESPACE': envConfig.vaultNamespace
   }
 }
-const vaultClient = vault(vaultOptions)
+const vaultFactory = () => vault(vaultOptions)
+
 // The Vault token is renewed only during polling, not asynchronously. The default tokenRenewThreshold
 // is three times larger than the pollerInterval so that the token is renewed before it
 // expires and with at least one remaining poll opportunty to retry renewal if it fails.
 const vaultTokenRenewThreshold = envConfig.vaultTokenRenewThreshold
   ? Number(envConfig.vaultTokenRenewThreshold) : 3 * envConfig.pollerIntervalMilliseconds / 1000
 const vaultBackend = new VaultBackend({
-  client: vaultClient,
+  vaultFactory: vaultFactory,
   tokenRenewThreshold: vaultTokenRenewThreshold,
   logger: logger,
   defaultVaultMountPoint: envConfig.defaultVaultMountPoint,

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -42,28 +42,30 @@ class VaultBackend extends KVBackend {
    * @returns {Promise} Promise object representing secret property values.
    */
   async _get ({ key, specOptions: { vaultMountPoint, vaultRole, kvVersion = 2 } }) {
-    let client = this._clients.get(vaultRole)
-
-    if (client === undefined) {
+    // Create cache key for auth specific client
+    const clientCacheKey = `|m${vaultMountPoint}|r${vaultRole}|`
+    // Lookup existing or create new vault client
+    let client = this._clients.get(clientCacheKey)
+    if (!client) {
       client = this._vaultFactory()
-      this._clients.set(vaultRole, client)
+      this._clients.set(clientCacheKey, client)
     }
 
     if (!client.token) {
       const jwt = this._fetchServiceAccountToken()
-      this._logger.debug(`fetching new token from vault for role ${vaultRole}`)
+      this._logger.debug(`fetching new token from vault for role ${vaultRole} on ${vaultMountPoint}`)
       await client.kubernetesLogin({
         mount_point: vaultMountPoint || this._defaultVaultMountPoint,
         role: vaultRole || this._defaultVaultRole,
         jwt: jwt
       })
     } else {
-      this._logger.debug(`checking vault token expiry for role ${vaultRole}`)
+      this._logger.debug(`checking vault token expiry for role ${vaultRole} on ${vaultMountPoint}`)
       const tokenStatus = await client.tokenLookupSelf()
-      this._logger.debug(`${vaultRole} vault token valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
+      this._logger.debug(`vault token (role ${vaultRole} on ${vaultMountPoint}) valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
 
       if (Number(tokenStatus.data.ttl) <= this._tokenRenewThreshold) {
-        this._logger.debug(`renewing ${vaultRole} vault token`)
+        this._logger.debug(`renewing role ${vaultRole} on ${vaultMountPoint} vault token`)
         await client.tokenRenewSelf()
       }
     }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -6,16 +6,17 @@ const KVBackend = require('./kv-backend')
 class VaultBackend extends KVBackend {
   /**
    * Create Vault backend.
-   * @param {Object} client - Client for interacting with Vault.
+   * @param {Object} vaultFactory - arrow function to create a vault client.
    * @param {Number} tokenRenewThreshold - tokens are renewed when ttl reaches this threshold
    * @param {Object} logger - Logger for logging stuff.
    */
   constructor ({ client, tokenRenewThreshold, logger, defaultVaultMountPoint, defaultVaultRole }) {
     super({ logger })
-    this._client = client
+    this._vaultFactory = vaultFactory
+    this._clients = new Map()
     this._tokenRenewThreshold = tokenRenewThreshold
-    this.defaultVaultMountPoint = defaultVaultMountPoint
-    this.defaultVaultRole = defaultVaultRole
+    this._defaultVaultMountPoint = defaultVaultMountPoint
+    this._defaultVaultRole = defaultVaultRole
   }
 
   /**
@@ -40,28 +41,35 @@ class VaultBackend extends KVBackend {
    * @param {number} specOptions.kvVersion - K/V Version 1 or 2
    * @returns {Promise} Promise object representing secret property values.
    */
-  async _get ({ key, specOptions: { vaultMountPoint = null, vaultRole = null, kvVersion = 2 } }) {
-    if (!this._client.token) {
+  async _get ({ key, specOptions: { vaultMountPoint, vaultRole, kvVersion = 2 } }) {
+    let client = this._clients.get(vaultRole)
+
+    if (client === undefined) {
+      client = this._vaultFactory()
+      this._clients.set(vaultRole, client)
+    }
+
+    if (!client.token) {
       const jwt = this._fetchServiceAccountToken()
-      this._logger.debug('fetching new token from vault')
-      await this._client.kubernetesLogin({
-        mount_point: vaultMountPoint || this.defaultVaultMountPoint,
-        role: vaultRole || this.defaultVaultRole,
+      this._logger.debug(`fetching new token from vault for role ${vaultRole}`)
+      await client.kubernetesLogin({
+        mount_point: vaultMountPoint || this._defaultVaultMountPoint,
+        role: vaultRole || this._defaultVaultRole,
         jwt: jwt
       })
     } else {
-      this._logger.debug('checking vault token expiry')
-      const tokenStatus = await this._client.tokenLookupSelf()
-      this._logger.debug(`vault token valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
+      this._logger.debug(`checking vault token expiry for role ${vaultRole}`)
+      const tokenStatus = await client.tokenLookupSelf()
+      this._logger.debug(`${vaultRole} vault token valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
 
       if (Number(tokenStatus.data.ttl) <= this._tokenRenewThreshold) {
-        this._logger.debug('renewing vault token')
-        await this._client.tokenRenewSelf()
+        this._logger.debug(`renewing ${vaultRole} vault token`)
+        await client.tokenRenewSelf()
       }
     }
 
     this._logger.debug(`reading secret key ${key} from vault`)
-    const secretResponse = await this._client.read(key)
+    const secretResponse = await client.read(key)
 
     if (kvVersion === 1) {
       return JSON.stringify(secretResponse.data)

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -42,10 +42,10 @@ class VaultBackend extends KVBackend {
    * @returns {Promise} Promise object representing secret property values.
    */
   async _get ({ key, specOptions: { vaultMountPoint = null, vaultRole = null, kvVersion = 2 } }) {
-    vaultMountPoint = vaultMountPoint || this._defaultVaultMountPoint
-    vaultRole = vaultRole || this._defaultVaultRole
+    const vaultMountPointGet = vaultMountPoint || this._defaultVaultMountPoint
+    const vaultRoleGet = vaultRole || this._defaultVaultRole
     // Create cache key for auth specific client
-    const clientCacheKey = `|m${vaultMountPoint}|r${vaultRole}|`
+    const clientCacheKey = `|m${vaultMountPointGet}|r${vaultRoleGet}|`
     // Lookup existing or create new vault client
     let client = this._clients.get(clientCacheKey)
     if (!client) {
@@ -55,19 +55,19 @@ class VaultBackend extends KVBackend {
 
     if (!client.token) {
       const jwt = this._fetchServiceAccountToken()
-      this._logger.debug(`fetching new token from vault for role ${vaultRole} on ${vaultMountPoint}`)
+      this._logger.debug(`fetching new token from vault for role ${vaultRoleGet} on ${vaultMountPointGet}`)
       await client.kubernetesLogin({
-        mount_point: vaultMountPoint,
-        role: vaultRole,
+        mount_point: vaultMountPointGet,
+        role: vaultRoleGet,
         jwt: jwt
       })
     } else {
-      this._logger.debug(`checking vault token expiry for role ${vaultRole} on ${vaultMountPoint}`)
+      this._logger.debug(`checking vault token expiry for role ${vaultRoleGet} on ${vaultMountPointGet}`)
       const tokenStatus = await client.tokenLookupSelf()
-      this._logger.debug(`vault token (role ${vaultRole} on ${vaultMountPoint}) valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
+      this._logger.debug(`vault token (role ${vaultRoleGet} on ${vaultMountPointGet}) valid for ${tokenStatus.data.ttl} seconds, renews at ${this._tokenRenewThreshold}`)
 
       if (Number(tokenStatus.data.ttl) <= this._tokenRenewThreshold) {
-        this._logger.debug(`renewing role ${vaultRole} on ${vaultMountPoint} vault token`)
+        this._logger.debug(`renewing role ${vaultRoleGet} on ${vaultMountPointGet} vault token`)
         await client.tokenRenewSelf()
       }
     }

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -10,7 +10,7 @@ class VaultBackend extends KVBackend {
    * @param {Number} tokenRenewThreshold - tokens are renewed when ttl reaches this threshold
    * @param {Object} logger - Logger for logging stuff.
    */
-  constructor ({ client, tokenRenewThreshold, logger, defaultVaultMountPoint, defaultVaultRole }) {
+  constructor ({ vaultFactory, tokenRenewThreshold, logger, defaultVaultMountPoint, defaultVaultRole }) {
     super({ logger })
     this._vaultFactory = vaultFactory
     this._clients = new Map()

--- a/lib/backends/vault-backend.js
+++ b/lib/backends/vault-backend.js
@@ -41,7 +41,9 @@ class VaultBackend extends KVBackend {
    * @param {number} specOptions.kvVersion - K/V Version 1 or 2
    * @returns {Promise} Promise object representing secret property values.
    */
-  async _get ({ key, specOptions: { vaultMountPoint, vaultRole, kvVersion = 2 } }) {
+  async _get ({ key, specOptions: { vaultMountPoint = null, vaultRole = null, kvVersion = 2 } }) {
+    vaultMountPoint = vaultMountPoint || this._defaultVaultMountPoint
+    vaultRole = vaultRole || this._defaultVaultRole
     // Create cache key for auth specific client
     const clientCacheKey = `|m${vaultMountPoint}|r${vaultRole}|`
     // Lookup existing or create new vault client
@@ -55,8 +57,8 @@ class VaultBackend extends KVBackend {
       const jwt = this._fetchServiceAccountToken()
       this._logger.debug(`fetching new token from vault for role ${vaultRole} on ${vaultMountPoint}`)
       await client.kubernetesLogin({
-        mount_point: vaultMountPoint || this._defaultVaultMountPoint,
-        role: vaultRole || this._defaultVaultRole,
+        mount_point: vaultMountPoint,
+        role: vaultRole,
         jwt: jwt
       })
     } else {

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -19,6 +19,7 @@ describe('VaultBackend', () => {
   const defaultFakeMountPoint = 'defaultFakeMountPoint'
   const defaultFakeRole = 'defaultFakeRole'
   const mountPoint = 'fakeMountPoint'
+  const mountPoint2 = 'fakeMountPoint2'
   const role = 'fakeRole'
   const role2 = 'fakeRole2'
   const secretKey = 'fakeSecretKey'
@@ -277,6 +278,53 @@ describe('VaultBackend', () => {
       sinon.assert.calledWith(clientMock2.kubernetesLogin, {
         mount_point: mountPoint,
         role: role2,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock2.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue2).equals(quotedSecretValue)
+    })
+
+    it('returns secret property value using client associated with mountpoint given in _get', async () => {
+      clientMock.read = sinon.stub().returns(kv2Secret)
+      clientMock2.read = sinon.stub().returns(kv2Secret)
+
+      const secretPropertyValue = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // First, we log into Vault with mountpoint 1...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals(quotedSecretValue)
+
+      const secretPropertyValue2 = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint2,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // Now ensure we log into Vault with mountpoint 2...
+      sinon.assert.calledWith(clientMock2.kubernetesLogin, {
+        mount_point: mountPoint2,
+        role: role,
         jwt: jwt
       })
 

--- a/lib/backends/vault-backend.test.js
+++ b/lib/backends/vault-backend.test.js
@@ -14,11 +14,13 @@ const logger = pino({
 
 describe('VaultBackend', () => {
   let clientMock
+  let clientMock2
   let vaultBackend
   const defaultFakeMountPoint = 'defaultFakeMountPoint'
   const defaultFakeRole = 'defaultFakeRole'
   const mountPoint = 'fakeMountPoint'
   const role = 'fakeRole'
+  const role2 = 'fakeRole2'
   const secretKey = 'fakeSecretKey'
   const secretValue = 'open, sesame'
   const secretData = { [secretKey]: secretValue }
@@ -50,9 +52,10 @@ describe('VaultBackend', () => {
 
   beforeEach(() => {
     clientMock = sinon.mock()
-
+    clientMock2 = sinon.mock()
+    let mock = 0
     vaultBackend = new VaultBackend({
-      client: clientMock,
+      vaultFactory: () => mock++ === 0 ? clientMock : clientMock2,
       tokenRenewThreshold: vaultTokenRenewThreshold,
       logger: logger,
       defaultVaultMountPoint: defaultFakeMountPoint,
@@ -63,6 +66,7 @@ describe('VaultBackend', () => {
   describe('_get', () => {
     beforeEach(() => {
       clientMock.read = sinon.stub().returns(kv2Secret)
+      clientMock.token = undefined
       clientMock.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
       clientMock.tokenRenewSelf = sinon.stub().returns(true)
       clientMock.kubernetesLogin = sinon.stub().returns({
@@ -71,9 +75,17 @@ describe('VaultBackend', () => {
         }
       })
 
-      vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
+      clientMock2.read = sinon.stub().returns(kv2Secret)
+      clientMock2.token = undefined
+      clientMock2.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultMustRenew)
+      clientMock2.tokenRenewSelf = sinon.stub().returns(true)
+      clientMock2.kubernetesLogin = sinon.stub().returns({
+        auth: {
+          client_token: '5678'
+        }
+      })
 
-      clientMock.token = undefined
+      vaultBackend._fetchServiceAccountToken = sinon.stub().returns(jwt)
     })
 
     it('logs in and returns secret property value - default', async () => {
@@ -226,6 +238,121 @@ describe('VaultBackend', () => {
 
       // ... and expect to get its proper value
       expect(secretPropertyValue).equals(quotedSecretValue)
+    })
+
+    it('returns secret property value using client associated with role given in _get', async () => {
+      clientMock.read = sinon.stub().returns(kv2Secret)
+      clientMock2.read = sinon.stub().returns(kv2Secret)
+
+      const secretPropertyValue = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // First, we log into Vault with role 1...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue).equals(quotedSecretValue)
+
+      const secretPropertyValue2 = await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role2
+        },
+        key: secretKey
+      })
+
+      // Now ensure we log into Vault with role 2...
+      sinon.assert.calledWith(clientMock2.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role2,
+        jwt: jwt
+      })
+
+      // ... then we fetch the secret ...
+      sinon.assert.calledWith(clientMock2.read, secretKey)
+
+      // ... and expect to get its proper value
+      expect(secretPropertyValue2).equals(quotedSecretValue)
+    })
+
+    it('ensure we cache the clients for each role', async () => {
+      clientMock.read = sinon.stub().returns(kv2Secret)
+      clientMock2.read = sinon.stub().returns(kv2Secret)
+
+      await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      // First, we log into Vault with role 1...
+      sinon.assert.calledWith(clientMock.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role,
+        jwt: jwt
+      })
+      sinon.assert.calledOnce(clientMock.read)
+
+      clientMock.token = 'an-existing-token'
+      clientMock.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultNoRenew)
+
+      // now we have active role 1 client, we now activate role 2 client
+
+      await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role2
+        },
+        key: secretKey
+      })
+
+      // we log into Vault with role 2...
+      sinon.assert.calledWith(clientMock2.kubernetesLogin, {
+        mount_point: mountPoint,
+        role: role2,
+        jwt: jwt
+      })
+      sinon.assert.calledOnce(clientMock2.read)
+
+      clientMock2.token = 'an-existing-token'
+      clientMock2.tokenLookupSelf = sinon.stub().returns(mockTokenLookupResultNoRenew)
+
+      // Back to role1
+      await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role
+        },
+        key: secretKey
+      })
+
+      sinon.assert.calledOnce(clientMock.kubernetesLogin)
+      sinon.assert.calledTwice(clientMock.read)
+
+      await vaultBackend._get({
+        specOptions: {
+          vaultMountPoint: mountPoint,
+          vaultRole: role2
+        },
+        key: secretKey
+      })
+
+      sinon.assert.calledOnce(clientMock2.kubernetesLogin)
+      sinon.assert.calledTwice(clientMock2.read)
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/godaddy/kubernetes-external-secrets/issues/487

When you have a single k8s cluster with multiple namespaces and each `ExternalSecret` is defined with a very limited scoped `vaultRole` (limiting the vault data that role can read) the existing token caching causes issues.

This change caches each `vaultClient` against the `vaultRole` it's authenticated against and can therefore KES can read all the secrets it is meant to regardless of how many `vaultRoles` are defined across your ExternalSecrets