### PR TITLE
chore(docs): Remove redundant -f in helm template

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more details about configuration see the [helm chart docs](charts/kubernetes
 If you don't want to install helm on your cluster and just want to use `kubectl` to install `kubernetes-external-secrets`, you could get the `helm` client cli first and then use the following sample command to generate kubernetes manifests:
 
 ```bash
-$ helm template -f charts/kubernetes-external-secrets/values.yaml --output-dir ./output_dir ./charts/kubernetes-external-secrets/
+$ helm template --output-dir ./output_dir ./charts/kubernetes-external-secrets/
 ```
 
 The generated kubernetes manifests will be in `./output_dir` and can be applied to deploy `kubernetes-external-secrets` to the cluster.


### PR DESCRIPTION
Having the default chart values being set with the `-f` flag is kinda confusing and redundant. Don't you think? 🤔 

Cheers!