### PR TITLE
fix: e2e tests to work with kind 0.9.0 + bump k8s version used

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,14 +19,10 @@ jobs:
     name: E2E
     strategy:
       matrix:
-        disableCustomResourceManager: ['true', 'false']
-        helmVersion: ['V2', 'V3']
+        disableCustomResourceManager: ["true", "false"]
+        helmVersion: ["V2", "V3"]
     steps:
       - uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
       - uses: azure/setup-helm@v1
         with:
           version: v2.16.1
@@ -35,5 +31,4 @@ jobs:
         run: |
           helm init --client-only
         if: matrix.helmVersion == 'V2'
-      - run: npm install
-      - run: npm run test-e2e -- ${{ matrix.disableCustomResourceManager }} ${{ matrix.helmVersion }}
+      - run: ./e2e/run-e2e-suite.sh ${{ matrix.disableCustomResourceManager }} ${{ matrix.helmVersion }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,4 @@ typings/
 .next
 
 # e2e test stuff
-e2e/.kubeconfig
+e2e/**/.kubeconfig

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:12.18.2-alpine
 
-RUN npm install npm@6.4.1 -g
-
 # Setup source directory
 RUN mkdir /app
 WORKDIR /app

--- a/e2e/kind.yaml
+++ b/e2e/kind.yaml
@@ -1,18 +1,18 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   apiServerPort: 6443
 kubeadmConfigPatches:
-- |
-  apiVersion: kubelet.config.k8s.io/v1beta1
-  kind: KubeletConfiguration
-  metadata:
-    name: config
-  # this is only relevant for btrfs uses
-  # https://github.com/kubernetes/kubernetes/issues/80633#issuecomment-550994513
-  featureGates:
-    LocalStorageCapacityIsolation: false
+  - |
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    kind: KubeletConfiguration
+    metadata:
+      name: config
+    # this is only relevant for btrfs uses
+    # https://github.com/kubernetes/kubernetes/issues/80633#issuecomment-550994513
+    featureGates:
+      LocalStorageCapacityIsolation: false
 nodes:
-- role: control-plane
-- role: worker
-- role: worker
+  - role: control-plane
+  - role: worker
+  - role: worker

--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -47,12 +47,12 @@ echo -e "${BGREEN}[dev-env] creating Kubernetes cluster with kind${NC}"
 kind create cluster \
   ${KIND_LOGGING} \
   --name ${KIND_CLUSTER_NAME} \
-  --config ${DIR}/kind.yaml \
+  --config "${DIR}/kind.yaml" \
   --image "kindest/node:${K8S_VERSION}"
 
 echo -e "${BGREEN}building external-secrets images${NC}"
-docker build -t external-secrets:test -f $DIR/../Dockerfile $DIR/../
-docker build -t external-secrets-e2e:test -f $DIR/Dockerfile $DIR/../
+docker build -t external-secrets:test -f "$DIR/../Dockerfile" "$DIR/../"
+docker build -t external-secrets-e2e:test -f "$DIR/Dockerfile" "$DIR/../"
 kind load docker-image --name="${KIND_CLUSTER_NAME}" external-secrets-e2e:test
 kind load docker-image --name="${KIND_CLUSTER_NAME}" external-secrets:test
 
@@ -60,7 +60,7 @@ function cleanup {
   set +e
   kubectl delete pod e2e 2>/dev/null
   kubectl delete crd/externalsecrets.kubernetes-client.io 2>/dev/null
-  kubectl delete -f ${DIR}/localstack.deployment.yaml 2>/dev/null
+  kubectl delete -f "${DIR}/localstack.deployment.yaml" 2>/dev/null
   kind delete cluster \
     ${KIND_LOGGING} \
     --name ${KIND_CLUSTER_NAME}

--- a/e2e/run-e2e-suite.sh
+++ b/e2e/run-e2e-suite.sh
@@ -18,7 +18,7 @@ DISABLE_CUSTOM_RESOURCE_MANAGER=${1:-true}
 HELM_VERSION=${2:-V3}
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-KIND_LOGGING="--quiet"
+KIND_LOGGING=""
 if ! [ -z "$DEBUG" ]; then
     set -x
     KIND_LOGGING="--verbosity=4"
@@ -35,7 +35,7 @@ RED='\e[35m'
 NC='\e[0m'
 BGREEN='\e[32m'
 
-K8S_VERSION=${K8S_VERSION:-v1.15.11}
+K8S_VERSION=${K8S_VERSION:-v1.16.15}
 KIND_CLUSTER_NAME="external-secrets-dev"
 REGISTRY=external-secrets
 


### PR DESCRIPTION
E2E test broke due to kind being bumped to 0.9.0 (not sure what and where the binary is provided? in the ubuntu CI image?)
api version for kind needed an update.