### PR TITLE
Add the ability to set the priorityClassName

### DIFF
--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -103,6 +103,7 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `serviceAccount.annotations`              | Annotations to be added to service account                                                                                        | `nil`                                 |
 | `podAnnotations`                          | Annotations to be added to pods                                                                                                   | `{}`                                  |
 | `podLabels`                               | Additional labels to be added to pods                                                                                             | `{}`                                  |
+| `priorityClassName`                       | Priority class to be assigned to pods
 | `replicaCount`                            | Number of replicas                                                                                                                | `1`                                   |
 | `nodeSelector`                            | node labels for pod assignment                                                                                                    | `{}`                                  |
 | `tolerations`                             | List of node taints to tolerate (requires Kubernetes >= 1.6)                                                                      | `[]`                                  |

--- a/charts/kubernetes-external-secrets/templates/deployment.yaml
+++ b/charts/kubernetes-external-secrets/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -85,6 +85,8 @@ fullnameOverride: ""
 podAnnotations: {}
 podLabels: {}
 
+priorityClassName: ""
+
 dnsConfig: {}
 
 securityContext:


### PR DESCRIPTION
This is a common feature of many Helm charts, and is important for
ensuring that the external-secrets pod is scheduled with a higher
priority than other workloads.