### PR TITLE
Better naming for Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,10 +614,10 @@ The secrets will persist even if the helm installation is removed, although they
 
 kubernetes-external-secrets exposes the following metrics over a prometheus endpoint:
 
-| Metric                                    | Description                                                                     | Example                                                                       |
-| ----------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| `sync_calls`                              | This metric counts the number of sync calls by backend, secret name and status  | `sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1` |
-| `last_state`                              | A value of -1 or 1 where -1 means the last sync_call was an error and 1 means the last sync_call was a success  | `last_state{name="foo",namespace="example",backend="foo"} 1` |
+| Metric                                             | Type    | Description                                                                     | Example                                                                       |
+| -------------------------------------------------- | ------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `kubernetes_external_secrets_sync_calls_count`     | Counter | Number of sync operations by backend, secret name and status                    | `kubernetes_external_secrets_sync_calls_count{name="foo",namespace="example",backend="foo",status="success"} 1` |
+| `kubernetes_external_secrets_last_sync_call_state` | Gauge   | State of last sync call of external secert, where -1 means the last sync_call was an error and 1 means the last sync_call was a success  | `kubernetes_external_secrets_last_sync_call_state{name="foo",namespace="example",backend="foo"} 1` |
 
 
 ## Development

--- a/lib/metrics-server.test.js
+++ b/lib/metrics-server.test.js
@@ -55,6 +55,12 @@ describe('MetricsServer', () => {
       .expect('Content-Type', Prometheus.register.contentType)
       .expect(200)
 
+    expect(res.text).to.have.string('kubernetes_external_secrets_sync_calls_count{name="foo",namespace="example",backend="foo",status="success"} 1')
+    expect(res.text).to.have.string('kubernetes_external_secrets_sync_calls_count{name="bar",namespace="example",backend="foo",status="failed"} 1')
+    expect(res.text).to.have.string('kubernetes_external_secrets_last_sync_call_state{name="foo",namespace="example",backend="foo"} 1')
+    expect(res.text).to.have.string('kubernetes_external_secrets_last_sync_call_state{name="bar",namespace="example",backend="foo"} -1')
+
+    // Deprecated metrics.
     expect(res.text).to.have.string('sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1')
     expect(res.text).to.have.string('sync_calls{name="bar",namespace="example",backend="foo",status="failed"} 1')
     expect(res.text).to.have.string('last_state{name="foo",namespace="example",backend="foo"} 1')

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -9,15 +9,27 @@ class Metrics {
    */
   constructor ({ registry }) {
     this._registry = registry
+    this._syncCallsCount = new Prometheus.Counter({
+      name: 'kubernetes_external_secrets_sync_calls_count',
+      help: 'Number of sync operations',
+      labelNames: ['name', 'namespace', 'backend', 'status'],
+      registers: [registry]
+    })
     this._syncCalls = new Prometheus.Counter({
       name: 'sync_calls',
-      help: 'number of sync operations',
+      help: '(Deprecated since 0.6.1, please use kubernetes_external_secrets_sync_calls_count) Number of sync operations',
       labelNames: ['name', 'namespace', 'backend', 'status'],
+      registers: [registry]
+    })
+    this._lastSyncCallState = new Prometheus.Gauge({
+      name: 'kubernetes_external_secrets_last_sync_call_state',
+      help: 'State of last sync call of external secert. Value -1 if the last sync was a failure, 1 otherwise',
+      labelNames: ['name', 'namespace', 'backend'],
       registers: [registry]
     })
     this._lastState = new Prometheus.Gauge({
       name: 'last_state',
-      help: 'Value -1 if the last sync was a failure, 1 otherwise.',
+      help: '(Deprecated since 0.6.1, please use kubernetes_external_secrets_last_sync_call_state) Value -1 if the last sync was a failure, 1 otherwise',
       labelNames: ['name', 'namespace', 'backend'],
       registers: [registry]
     })
@@ -31,6 +43,12 @@ class Metrics {
    * @param {String} status - the result of the sync process: error|success
    */
   observeSync ({ name, namespace, backend, status }) {
+    this._syncCallsCount.inc({
+      name,
+      namespace,
+      backend,
+      status
+    })
     this._syncCalls.inc({
       name,
       namespace,
@@ -38,12 +56,22 @@ class Metrics {
       status
     })
     if (status === 'success') {
+      this._lastSyncCallState.set({
+        name,
+        namespace,
+        backend
+      }, 1)
       this._lastState.set({
         name,
         namespace,
         backend
       }, 1)
     } else {
+      this._lastSyncCallState.set({
+        name,
+        namespace,
+        backend
+      }, -1)
       this._lastState.set({
         name,
         namespace,

--- a/lib/metrics.test.js
+++ b/lib/metrics.test.js
@@ -27,6 +27,8 @@ describe('Metrics', () => {
       backend: 'foo',
       status: 'success'
     })
+    expect(registry.metrics()).to.have.string('kubernetes_external_secrets_sync_calls_count{name="foo",namespace="example",backend="foo",status="success"} 1')
+    // Deprecated metric.
     expect(registry.metrics()).to.have.string('sync_calls{name="foo",namespace="example",backend="foo",status="success"} 1')
   })
 })


### PR DESCRIPTION
Hello,

This PR refactors the metrics' names according to  [Prometheus metric names best practices](https://prometheus.io/docs/practices/naming/#metric-names).

No breaking changes at the moment since I added new metrics and added deprecation notes on the old ones.

Related to: #489