### PR TITLE
Bumping lodash from 4.17.19 to 4.17.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15698,9 +15698,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",


### PR DESCRIPTION
As per Snyk report (https://snyk.io/test/npm/lodash/4.17.19), bumping lodash version to latest one, as 4.17.19 contains high severity Prototype Pollution