### PR TITLE
Bumping @grpc/grpc-js to 1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11386,9 +11386,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.7.tgz",
-      "integrity": "sha512-EuxMstI0u778dp0nk6Fe3gHXYPeV6FYsWOe0/QFwxv1NQ6bc5Wl/0Yxa4xl9uBlKElL6AIxuASmSfu7KEJhqiw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.1.8.tgz",
+      "integrity": "sha512-64hg5rmEm6F/NvlWERhHmmgxbWU8nD2TMWE+9TvG7/WcOrFT3fzg/Uu631pXRFwmJ4aWO/kp9vVSlr8FUjBDLA==",
       "requires": {
         "@grpc/proto-loader": "^0.6.0-pre14",
         "@types/node": "^12.12.47",


### PR DESCRIPTION
Bumping @grpc/grpc-js to 1.1.8 to address  Prototype Pollution issue: https://app.snyk.io/vuln/SNYK-JS-GRPCGRPCJS-1038818